### PR TITLE
Readr v2.2 Sprint 1 — Books API Contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v2.2-sprint-1] — Books API Contract (2026-03-10)
+
+### Added
+
+- Implemented Books CRUD endpoints for `GET`, `POST`, `PATCH`, and `DELETE`
+- Added Books DTO mapper for stable frontend-facing response shapes
+- Added Books service layer for Prisma-backed persistence
+- Added status transition timestamp handling for `planned`, `reading`, and `finished`
+
+### Changed
+
+- Tightened Books Zod schemas for create, update, params, query, and response validation
+- Standardized delete behavior to return `204 No Content`
+- Synced Prisma schema and database contract for current Books fields
+
+### Fixed
+
+- Resolved local schema/database mismatch causing Prisma read failures
+- Fixed timestamp update typo affecting status transition PATCH behavior
+- Fixed Zod v4 startup issue in sessions schema by using `.safeExtend()`
+
+### Notes
+
+- Postman validation passed for valid CRUD flows, invalid payloads, missing resources, and timestamp contract behavior
+
+---
+
 ## [v2.2-sprint-0] — Schema & Contract Audit (2026-03-08)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A versioned full-stack reading tracker built to demonstrate modern frontend arch
   <img src="https://img.shields.io/github/actions/workflow/status/conorgregson/readr-v2/ci.yml?style=for-the-badge&label=CI&logo=github" />
 </a>
 
-<img src="https://img.shields.io/badge/Status-v2.1%20Released-FFA500?style=for-the-badge" />
+<img src="https://img.shields.io/badge/Status-v2.2%20In%20Development-orange?style=for-the-badge" />
 <img src="https://img.shields.io/badge/Commits-Signed%20(Verified)-00C853?style=for-the-badge&logo=github" />
 
 </p>
@@ -39,9 +39,9 @@ Try the deployed frontend here:
 https://readr-v2-app.vercel.app
 
 The demo currently runs **client-side only** using localStorage.
-Your reading data is stored in your browser and will persist until site data is cleared.
+Your reading data is stored in your browser and will persist until site data is cleared. This reflects the **v2.1 parity release**.
 
-Server-backed persistence will be introduced in **v2.2**.
+Server-backed persistence will be introduced in **v2.2**, connecting the deployed UI to the API layer.
 
 ---
 
@@ -207,10 +207,12 @@ Only SemVer releases represent official “ship-ready” states.
 
 ## Roadmap (High-Level)
 
-- **v2.0.0** — Backend & CI foundation ✅
-- **v2.1.0** — React frontend rebuild with v1.9 behavioral parity ✅
-- **v2.2.0** — API integration & persistence (in progress)
-- **v2.3.0+** — Accounts, analytics, and growth features
+- **v2.0.0** — Backend & CI foundation (Express + Prisma + PostgreSQL) ✅
+- **v2.1.0** — React frontend rebuild with full v1.9 behavioral parity ✅
+- **v2.2.0** — API integration & persistence migration (local-first → API) 🚧
+- **v2.3.0** — Authentication, accounts, and multi-user data boundaries
+- **v2.4.0** — Server-driven badges, statistics, and engagement systems
+- **v3.0.0** — Production infrastructure & hosted deployment architecture
 
 For detailed version history and architectural milestones, see [`roadmap.md`](./roadmap.md).
 

--- a/docs/sprints/v2.2-sprint-1-blueprint.md
+++ b/docs/sprints/v2.2-sprint-1-blueprint.md
@@ -22,7 +22,8 @@ At the end of this sprint:
 
 Endpoints:
 
-- GET /api/books
+GET /api/books
+
 - POST /api/books
 - PATCH /api/books/:id
 - DELETE /api/books/:id

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,14 +586,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "client/node_modules/@types/react": {
-      "version": "19.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "client/node_modules/@types/react-dom": {
       "version": "19.2.3",
       "dev": true,
@@ -907,17 +899,6 @@
         "node": ">= 8"
       }
     },
-    "client/node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "client/node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
@@ -1169,11 +1150,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "client/node_modules/csstype": {
-      "version": "3.2.3",
-      "dev": true,
-      "license": "MIT"
     },
     "client/node_modules/deep-is": {
       "version": "0.1.4",
@@ -2007,17 +1983,6 @@
         "node": ">=8.10.0"
       }
     },
-    "client/node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "client/node_modules/resolve-from": {
       "version": "4.0.0",
       "dev": true,
@@ -2471,6 +2436,43 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -2612,6 +2614,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
+      "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-socket": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
+      "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "pglite-server": "dist/scripts/server.js"
+      },
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.15"
+      }
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
+      "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.15"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3136,12 +3168,39 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mrleebo/prisma-ast": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
+      "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "^10.5.0",
+        "lilconfig": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -3195,29 +3254,187 @@
       }
     },
     "node_modules/@prisma/adapter-pg": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.1.0.tgz",
-      "integrity": "sha512-DSAnUwkKfX4bUzhkrjGN4IBQzwg0nvFw2W17H0Oa532I5w9nLtTJ9mAEGDs1nUBEGRAsa0c7qsf8CSgfJ4DsBQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.4.2.tgz",
+      "integrity": "sha512-oUo2Zhe9Tf6YwVL8kLPuOLTK1Z2pwi/Ua77t2PuGyBan2w7shRKqHvYK+3XXmRH9RWhPJ4SMtHZKpNo6Ax/4bQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/driver-adapter-utils": "7.1.0",
+        "@prisma/driver-adapter-utils": "7.4.2",
         "pg": "^8.16.3",
         "postgres-array": "3.0.4"
       }
     },
-    "node_modules/@prisma/debug": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.1.0.tgz",
-      "integrity": "sha512-pPAckG6etgAsEBusmZiFwM9bldLSNkn++YuC4jCTJACdK5hLOVnOzX7eSL2FgaU6Gomd6wIw21snUX2dYroMZQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/driver-adapter-utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.1.0.tgz",
-      "integrity": "sha512-AlVLzeXkw81+47MvQ9M8DvTiHkRfJ8xzklTbYjpskb0cTTDVHboTI/OVwT6Wcep/bNvfLKJYO0nylBiM5rxgww==",
+    "node_modules/@prisma/client": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.1.0"
+        "@prisma/client-runtime-utils": "7.4.2"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.4.2.tgz",
+      "integrity": "sha512-cID+rzOEb38VyMsx5LwJMEY4NGIrWCNpKu/0ImbeooQ2Px7TI+kOt7cm0NelxUzF2V41UVVXAmYjANZQtCu1/Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/config": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.2.tgz",
+      "integrity": "sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.18.4",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.2.tgz",
+      "integrity": "sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
+      "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electric-sql/pglite": "0.3.15",
+        "@electric-sql/pglite-socket": "0.0.20",
+        "@electric-sql/pglite-tools": "0.2.20",
+        "@hono/node-server": "1.19.9",
+        "@mrleebo/prisma-ast": "0.13.1",
+        "@prisma/get-platform": "7.2.0",
+        "@prisma/query-plan-executor": "7.2.0",
+        "foreground-child": "3.3.1",
+        "get-port-please": "3.2.0",
+        "hono": "4.11.4",
+        "http-status-codes": "2.3.0",
+        "pathe": "2.0.3",
+        "proper-lockfile": "4.1.2",
+        "remeda": "2.33.4",
+        "std-env": "3.10.0",
+        "valibot": "1.2.0",
+        "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.4.2.tgz",
+      "integrity": "sha512-REdjFpT/ye9KdDs+CXAXPIbMQkVLhne9G5Pe97sNY4Ovx4r2DAbWM9hOFvvB1Oq8H8bOCdu0Ri3AoGALquQqVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.2.tgz",
+      "integrity": "sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2",
+        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+        "@prisma/fetch-engine": "7.4.2",
+        "@prisma/get-platform": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919.tgz",
+      "integrity": "sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
+      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.2.tgz",
+      "integrity": "sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2",
+        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+        "@prisma/get-platform": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
+      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
+      "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.2.0"
+      }
+    },
+    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
+      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/query-plan-executor": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
+      "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
+      "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3699,6 +3916,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -4025,6 +4252,16 @@
         "node": "*"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/aws4": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
@@ -4033,14 +4270,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -4131,6 +4368,35 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
       }
     },
     "node_modules/call-bind": {
@@ -4240,6 +4506,47 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
+      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/cli-progress": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
@@ -4330,6 +4637,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -4413,6 +4737,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/csv-parse": {
       "version": "4.16.3",
@@ -4527,6 +4858,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4563,6 +4904,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4571,6 +4919,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dequal": {
@@ -4594,6 +4952,23 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -4601,6 +4976,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4634,12 +5022,33 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/effect": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -4980,6 +5389,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4996,6 +5412,29 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5095,6 +5534,100 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -5184,6 +5717,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -5231,6 +5774,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
@@ -5316,6 +5866,24 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -5351,6 +5919,20 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/grammex": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
+      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/graphmatch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
+      "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -5532,6 +6114,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -5601,6 +6193,13 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/httpntlm": {
       "version": "1.8.13",
@@ -5703,6 +6302,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5999,6 +6608,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6207,6 +6823,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/joi": {
       "version": "18.0.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
@@ -6383,6 +7009,16 @@
         "node": "> 0.8"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/liquid-json": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/liquid-json/-/liquid-json-0.3.1.tgz",
@@ -6416,6 +7052,13 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -6427,6 +7070,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/lz-string": {
@@ -6639,6 +7298,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mysql2": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6666,9 +7376,9 @@
       "license": "MIT"
     },
     "node_modules/newman": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/newman/-/newman-6.2.1.tgz",
-      "integrity": "sha512-Zq8Sr5GFF+OXs5yIbyglLMKMh1WNMjYVV0yZaSBZ+DIgQOIWcxT8QTfbrl/YUGrLyT4rjpu+yZ/Z+kozw79GEA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/newman/-/newman-6.2.2.tgz",
+      "integrity": "sha512-BmGzMz6f2FLtw/hHAbhEAVqXS+3APJGAWzlxVijSElFaxC37wpHEqsOB09d/2uHMvTyMXGArtbFa+z5m/a68Uw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6686,7 +7396,7 @@
         "mkdirp": "3.0.1",
         "postman-collection": "4.4.0",
         "postman-collection-transformer": "4.1.8",
-        "postman-request": "2.88.1-postman.34",
+        "postman-request": "2.88.1-postman.48",
         "postman-runtime": "7.39.1",
         "pretty-ms": "7.0.1",
         "semver": "7.6.3",
@@ -6859,6 +7569,69 @@
         "node": ">=8"
       }
     },
+    "node_modules/newman/node_modules/http-signature": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.18.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/newman/node_modules/postman-request": {
+      "version": "2.88.1-postman.48",
+      "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.48.tgz",
+      "integrity": "sha512-E32FGh8ig2KDvzo4Byi7Ibr+wK2gNKPSqXoNsvjdCHgDBxSK4sCUwv+aa3zOBUwfiibPImHMy0WdlDSSCTqTuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@postman/form-data": "~3.1.1",
+        "@postman/tough-cookie": "~4.1.3-postman.1",
+        "@postman/tunnel-agent": "^0.6.8",
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.12.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "http-signature": "~1.4.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "^2.1.35",
+        "oauth-sign": "~0.9.0",
+        "qs": "~6.14.1",
+        "safe-buffer": "^5.1.2",
+        "socks-proxy-agent": "^8.0.5",
+        "stream-length": "^1.0.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/newman/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/newman/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -6877,6 +7650,13 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-forge": {
@@ -6958,6 +7738,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -7030,6 +7835,13 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/onetime": {
@@ -7152,6 +7964,13 @@
       "dependencies": {
         "through": "~2.3"
       }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -7301,6 +8120,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7338,6 +8169,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "devOptional": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/postgres-array": {
@@ -7627,6 +8472,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prisma": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.2.tgz",
+      "integrity": "sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "7.4.2",
+        "@prisma/dev": "0.20.0",
+        "@prisma/engines": "7.4.2",
+        "@prisma/studio-core": "0.13.1",
+        "mysql2": "3.15.3",
+        "postgres": "3.4.7"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": ">=9.0.0",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7673,6 +8564,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
@@ -7689,6 +8597,17 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -7772,6 +8691,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/readr-v2-server": {
       "resolved": "server",
       "link": true
@@ -7812,6 +8745,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -7867,6 +8807,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/remeda": {
+      "version": "2.33.4",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
+      "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -7903,6 +8853,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -8079,6 +9039,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
+      "devOptional": true
     },
     "node_modules/serialised-error": {
       "version": "1.1.3",
@@ -8284,7 +9250,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/sirv": {
@@ -8300,6 +9266,47 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-map": {
@@ -8380,6 +9387,16 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -8458,7 +9475,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -9087,6 +10104,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -9557,6 +10589,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/zeptomatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
+      "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "grammex": "^3.1.11",
+        "graphmatch": "^1.1.0"
+      }
+    },
     "node_modules/zod": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
@@ -9600,8 +10643,8 @@
       "version": "2.0.0",
       "license": "CC-BY-NC-4.0",
       "dependencies": {
-        "@prisma/adapter-pg": "^7.1.0",
-        "@prisma/client": "^7.1.0",
+        "@prisma/adapter-pg": "^7.4.2",
+        "@prisma/client": "^7.4.2",
         "cors": "^2.8.5",
         "express": "^4.19.0",
         "helmet": "^7.0.0",
@@ -9615,41 +10658,12 @@
         "kill-port": "^2.0.1",
         "newman": "^6.2.1",
         "newman-reporter-htmlextra": "^1.23.1",
-        "prisma": "^7.1.0",
+        "prisma": "^7.4.2",
         "start-server-and-test": "^2.1.3",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.0",
         "wait-on": "^9.0.3"
       }
-    },
-    "server/node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.5.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "server/node_modules/@chevrotain/gast": {
-      "version": "10.5.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "10.5.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "server/node_modules/@chevrotain/types": {
-      "version": "10.5.0",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/@chevrotain/utils": {
-      "version": "10.5.0",
-      "devOptional": true,
-      "license": "Apache-2.0"
     },
     "server/node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -9660,41 +10674,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "server/node_modules/@electric-sql/pglite": {
-      "version": "0.3.2",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/@electric-sql/pglite-socket": {
-      "version": "0.0.6",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "pglite-server": "dist/scripts/server.js"
-      },
-      "peerDependencies": {
-        "@electric-sql/pglite": "0.3.2"
-      }
-    },
-    "server/node_modules/@electric-sql/pglite-tools": {
-      "version": "0.2.7",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@electric-sql/pglite": "0.3.2"
-      }
-    },
-    "server/node_modules/@hono/node-server": {
-      "version": "1.19.6",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "server/node_modules/@jridgewell/resolve-uri": {
@@ -9712,150 +10691,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "server/node_modules/@mrleebo/prisma-ast": {
-      "version": "0.12.1",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chevrotain": "^10.5.0",
-        "lilconfig": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "server/node_modules/@prisma/client": {
-      "version": "7.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/client-runtime-utils": "7.1.0"
-      },
-      "engines": {
-        "node": "^20.19 || ^22.12 || >=24.0"
-      },
-      "peerDependencies": {
-        "prisma": "*",
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "server/node_modules/@prisma/client-runtime-utils": {
-      "version": "7.1.0",
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/@prisma/config": {
-      "version": "7.1.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "c12": "3.1.0",
-        "deepmerge-ts": "7.1.5",
-        "effect": "3.18.4",
-        "empathic": "2.0.0"
-      }
-    },
-    "server/node_modules/@prisma/dev": {
-      "version": "0.15.0",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "@electric-sql/pglite": "0.3.2",
-        "@electric-sql/pglite-socket": "0.0.6",
-        "@electric-sql/pglite-tools": "0.2.7",
-        "@hono/node-server": "1.19.6",
-        "@mrleebo/prisma-ast": "0.12.1",
-        "@prisma/get-platform": "6.8.2",
-        "@prisma/query-plan-executor": "6.18.0",
-        "foreground-child": "3.3.1",
-        "get-port-please": "3.1.2",
-        "hono": "4.10.6",
-        "http-status-codes": "2.3.0",
-        "pathe": "2.0.3",
-        "proper-lockfile": "4.1.2",
-        "remeda": "2.21.3",
-        "std-env": "3.9.0",
-        "valibot": "1.2.0",
-        "zeptomatch": "2.0.2"
-      }
-    },
-    "server/node_modules/@prisma/engines": {
-      "version": "7.1.0",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "7.1.0",
-        "@prisma/engines-version": "7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba",
-        "@prisma/fetch-engine": "7.1.0",
-        "@prisma/get-platform": "7.1.0"
-      }
-    },
-    "server/node_modules/@prisma/engines-version": {
-      "version": "7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.1.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "7.1.0"
-      }
-    },
-    "server/node_modules/@prisma/fetch-engine": {
-      "version": "7.1.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "7.1.0",
-        "@prisma/engines-version": "7.1.0-6.ab635e6b9d606fa5c8fb8b1a7f909c3c3c1c98ba",
-        "@prisma/get-platform": "7.1.0"
-      }
-    },
-    "server/node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.1.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "7.1.0"
-      }
-    },
-    "server/node_modules/@prisma/get-platform": {
-      "version": "6.8.2",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.8.2"
-      }
-    },
-    "server/node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
-      "version": "6.8.2",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/@prisma/query-plan-executor": {
-      "version": "6.18.0",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/@prisma/studio-core": {
-      "version": "0.8.2",
-      "devOptional": true,
-      "license": "UNLICENSED",
-      "peerDependencies": {
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "server/node_modules/@tsconfig/node10": {
@@ -9961,15 +10796,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "server/node_modules/@types/react": {
-      "version": "19.2.7",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "server/node_modules/@types/send": {
       "version": "1.2.1",
       "dev": true,
@@ -10061,14 +10887,6 @@
       "version": "1.1.1",
       "license": "MIT"
     },
-    "server/node_modules/aws-ssl-profiles": {
-      "version": "1.1.2",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "server/node_modules/binary-extensions": {
       "version": "2.3.0",
       "dev": true,
@@ -10114,72 +10932,6 @@
         "node": ">= 0.8"
       }
     },
-    "server/node_modules/c12": {
-      "version": "3.1.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^4.0.3",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^16.6.1",
-        "exsolve": "^1.0.7",
-        "giget": "^2.0.0",
-        "jiti": "^2.4.2",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
-        "rc9": "^2.1.2"
-      },
-      "peerDependencies": {
-        "magicast": "^0.3.5"
-      },
-      "peerDependenciesMeta": {
-        "magicast": {
-          "optional": true
-        }
-      }
-    },
-    "server/node_modules/c12/node_modules/chokidar": {
-      "version": "4.0.3",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "server/node_modules/c12/node_modules/readdirp": {
-      "version": "4.1.2",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "server/node_modules/chevrotain": {
-      "version": "10.5.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.5.0",
-        "@chevrotain/gast": "10.5.0",
-        "@chevrotain/types": "10.5.0",
-        "@chevrotain/utils": "10.5.0",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
-      }
-    },
     "server/node_modules/chokidar": {
       "version": "3.6.0",
       "dev": true,
@@ -10201,27 +10953,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "server/node_modules/citty": {
-      "version": "0.1.6",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
-    },
-    "server/node_modules/confbox": {
-      "version": "0.2.2",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/consola": {
-      "version": "3.4.2",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "server/node_modules/content-disposition": {
@@ -10268,51 +10999,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "server/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "server/node_modules/csstype": {
-      "version": "3.2.3",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true
-    },
     "server/node_modules/debug": {
       "version": "2.6.9",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "server/node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "devOptional": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "server/node_modules/defu": {
-      "version": "6.1.4",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/denque": {
-      "version": "2.1.0",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "server/node_modules/depd": {
@@ -10322,36 +11013,12 @@
         "node": ">= 0.8"
       }
     },
-    "server/node_modules/destr": {
-      "version": "2.0.5",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "server/node_modules/destroy": {
       "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "server/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "server/node_modules/dotenv": {
-      "version": "16.6.1",
-      "devOptional": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "server/node_modules/dynamic-dedupe": {
@@ -10365,23 +11032,6 @@
     "server/node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT"
-    },
-    "server/node_modules/effect": {
-      "version": "3.18.4",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "fast-check": "^3.23.1"
-      }
-    },
-    "server/node_modules/empathic": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "server/node_modules/encodeurl": {
       "version": "2.0.0",
@@ -10445,32 +11095,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "server/node_modules/exsolve": {
-      "version": "1.0.8",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/fast-check": {
-      "version": "3.23.2",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "pure-rand": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "server/node_modules/finalhandler": {
       "version": "1.3.2",
       "license": "MIT",
@@ -10485,21 +11109,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "server/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "server/node_modules/forwarded": {
@@ -10520,35 +11129,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "server/node_modules/generate-function": {
-      "version": "2.3.1",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "server/node_modules/get-port-please": {
-      "version": "3.1.2",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/giget": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
-      "bin": {
-        "giget": "dist/cli.mjs"
-      }
     },
     "server/node_modules/glob": {
       "version": "7.2.3",
@@ -10580,24 +11160,11 @@
         "node": ">= 6"
       }
     },
-    "server/node_modules/grammex": {
-      "version": "3.1.12",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "server/node_modules/helmet": {
       "version": "7.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "server/node_modules/hono": {
-      "version": "4.10.6",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "server/node_modules/http-errors": {
@@ -10617,11 +11184,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "server/node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "devOptional": true,
-      "license": "MIT"
     },
     "server/node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -10658,46 +11220,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "server/node_modules/is-property": {
-      "version": "1.0.2",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/jiti": {
-      "version": "2.6.1",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "server/node_modules/lilconfig": {
-      "version": "2.1.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "server/node_modules/long": {
-      "version": "5.3.2",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "server/node_modules/lru.min": {
-      "version": "1.1.3",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "bun": ">=1.0.0",
-        "deno": ">=1.30.0",
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "server/node_modules/make-error": {
@@ -10751,62 +11273,12 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "server/node_modules/mysql2": {
-      "version": "3.15.3",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "aws-ssl-profiles": "^1.1.1",
-        "denque": "^2.1.0",
-        "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.0",
-        "long": "^5.2.1",
-        "lru.min": "^1.0.0",
-        "named-placeholders": "^1.1.3",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "server/node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "server/node_modules/named-placeholders": {
-      "version": "1.1.4",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru.min": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "server/node_modules/negotiator": {
       "version": "0.6.3",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "server/node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "devOptional": true,
-      "license": "MIT"
     },
     "server/node_modules/normalize-path": {
       "version": "3.0.0",
@@ -10816,35 +11288,12 @@
         "node": ">=0.10.0"
       }
     },
-    "server/node_modules/nypm": {
-      "version": "0.6.2",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": "^14.16.0 || >=16.10.0"
-      }
-    },
     "server/node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "server/node_modules/ohash": {
-      "version": "2.0.11",
-      "devOptional": true,
-      "license": "MIT"
     },
     "server/node_modules/on-finished": {
       "version": "2.4.1",
@@ -10879,91 +11328,9 @@
         "node": ">=0.10.0"
       }
     },
-    "server/node_modules/path-key": {
-      "version": "3.1.1",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "server/node_modules/path-to-regexp": {
       "version": "0.1.12",
       "license": "MIT"
-    },
-    "server/node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/pkg-types": {
-      "version": "2.3.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
-        "pathe": "^2.0.3"
-      }
-    },
-    "server/node_modules/postgres": {
-      "version": "3.4.7",
-      "devOptional": true,
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/porsager"
-      }
-    },
-    "server/node_modules/prisma": {
-      "version": "7.1.0",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/config": "7.1.0",
-        "@prisma/dev": "0.15.0",
-        "@prisma/engines": "7.1.0",
-        "@prisma/studio-core": "0.8.2",
-        "mysql2": "3.15.3",
-        "postgres": "3.4.7"
-      },
-      "bin": {
-        "prisma": "build/index.js"
-      },
-      "engines": {
-        "node": "^20.19 || ^22.12 || >=24.0"
-      },
-      "peerDependencies": {
-        "better-sqlite3": ">=9.0.0",
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "better-sqlite3": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "server/node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "server/node_modules/proper-lockfile/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "devOptional": true,
-      "license": "ISC"
     },
     "server/node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -10976,23 +11343,10 @@
         "node": ">= 0.10"
       }
     },
-    "server/node_modules/pure-rand": {
-      "version": "6.1.0",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
     "server/node_modules/qs": {
-      "version": "6.14.0",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11024,15 +11378,6 @@
         "node": ">= 0.8"
       }
     },
-    "server/node_modules/rc9": {
-      "version": "2.1.2",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
-      }
-    },
     "server/node_modules/readdirp": {
       "version": "3.6.0",
       "dev": true,
@@ -11042,27 +11387,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "server/node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "server/node_modules/remeda": {
-      "version": "2.21.3",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.39.1"
-      }
-    },
-    "server/node_modules/retry": {
-      "version": "0.12.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "server/node_modules/rimraf": {
@@ -11122,10 +11446,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "server/node_modules/seq-queue": {
-      "version": "0.0.5",
-      "devOptional": true
     },
     "server/node_modules/serve-static": {
       "version": "1.16.2",
@@ -11198,36 +11518,6 @@
       "version": "1.2.0",
       "license": "ISC"
     },
-    "server/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "server/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "server/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "server/node_modules/source-map-support": {
       "version": "0.5.21",
       "dev": true,
@@ -11237,25 +11527,12 @@
         "source-map": "^0.6.0"
       }
     },
-    "server/node_modules/sqlstring": {
-      "version": "2.3.3",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "server/node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "server/node_modules/std-env": {
-      "version": "3.9.0",
-      "devOptional": true,
-      "license": "MIT"
     },
     "server/node_modules/strip-json-comments": {
       "version": "2.0.1",
@@ -11366,17 +11643,6 @@
         "strip-json-comments": "^2.0.0"
       }
     },
-    "server/node_modules/type-fest": {
-      "version": "4.41.0",
-      "devOptional": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "server/node_modules/type-is": {
       "version": "1.6.18",
       "license": "MIT",
@@ -11390,7 +11656,7 @@
     },
     "server/node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11424,38 +11690,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "server/node_modules/valibot": {
-      "version": "1.2.0",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "server/node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "server/node_modules/which": {
-      "version": "2.0.2",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "server/node_modules/wrappy": {
@@ -11469,14 +11708,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "server/node_modules/zeptomatch": {
-      "version": "2.0.2",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "grammex": "^3.1.10"
       }
     }
   }

--- a/roadmap.md
+++ b/roadmap.md
@@ -174,9 +174,10 @@ Released: Mar 2026
 
 ### Notes
 
-- v2.2 is a **persistence migration**, not a UX redesign.
+- v2.2 is a persistence migration, not a UX redesign.
 - The React UI should remain materially unchanged.
 - Frontend domain types from v2.1 are treated as the canonical contract.
+- A client-only demo is already deployed via Vercel; v2.2 will connect the UI to the API layer.
 
 Planned: Q2 2026
 
@@ -216,14 +217,16 @@ Planned: TBD
 
 ## 🌍 Version 3.0 — Deployment & Growth
 
-**Focus:** Transition Readr from a local development project into a production-ready, publicly accessible application.
+**Focus:** Harden Readr for production infrastructure and public hosting at scale.
 
 ### Planned Work
 
-- Cloud deployment (frontend + backend)
-- CI/CD pipeline
-- Public demo environment
+- Production hosting architecture
+- CI/CD deployment pipelines
 - Environment-based configuration
+- Production database infrastructure
+- Public demo environment stabilization
+- Monitoring and logging baseline
 
 Planned: TBD
 

--- a/server/package.json
+++ b/server/package.json
@@ -9,23 +9,19 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "start:ci": "node dist/index.js",
-
     "typecheck": "tsc --noEmit",
     "test": "echo \"No server tests defined yet\" && exit 0",
-
     "prisma": "prisma",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",
-
     "test:api": "newman run postman/Readr-v2-API.postman_collection.json -e postman/Readr-v2-Local.postman_environment.json --color on",
     "test:api:html": "newman run postman/Readr-v2-API.postman_collection.json -e postman/Readr-v2-Local.postman_environment.json --reporters cli,htmlextra --reporter-htmlextra-export postman/reports/api-report.html --color on",
-
     "prestart:api:ci": "kill-port 4000 || true",
     "test:api:ci": "npm run build && start-server-and-test \"npm run start:ci\" http://localhost:4000/health \"npm run test:api\""
   },
   "dependencies": {
-    "@prisma/adapter-pg": "^7.1.0",
-    "@prisma/client": "^7.1.0",
+    "@prisma/adapter-pg": "^7.4.2",
+    "@prisma/client": "^7.4.2",
     "cors": "^2.8.5",
     "express": "^4.19.0",
     "helmet": "^7.0.0",
@@ -39,7 +35,7 @@
     "kill-port": "^2.0.1",
     "newman": "^6.2.1",
     "newman-reporter-htmlextra": "^1.23.1",
-    "prisma": "^7.1.0",
+    "prisma": "^7.4.2",
     "start-server-and-test": "^2.1.3",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.0",

--- a/server/prisma/migrations/20260310052731_v2_2/migration.sql
+++ b/server/prisma/migrations/20260310052731_v2_2/migration.sql
@@ -1,0 +1,64 @@
+/*
+  Warnings:
+
+  - The values [PLANNED,READING,FINISHED,ABANDONED] on the enum `BookStatus` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the column `currentPage` on the `Book` table. All the data in the column will be lost.
+  - You are about to drop the column `pageCount` on the `Book` table. All the data in the column will be lost.
+  - Made the column `author` on table `Book` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- CreateEnum
+CREATE TYPE "SeriesType" AS ENUM ('series', 'standalone');
+
+-- CreateEnum
+CREATE TYPE "FormatParent" AS ENUM ('digital', 'physical');
+
+-- CreateEnum
+CREATE TYPE "FormatSubtype" AS ENUM ('Hardcover', 'Paperback', 'ebook', 'Audiobook', 'PDF');
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "BookStatus_new" AS ENUM ('planned', 'reading', 'finished');
+ALTER TABLE "public"."Book" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Book" ALTER COLUMN "status" TYPE "BookStatus_new" USING ("status"::text::"BookStatus_new");
+ALTER TYPE "BookStatus" RENAME TO "BookStatus_old";
+ALTER TYPE "BookStatus_new" RENAME TO "BookStatus";
+DROP TYPE "public"."BookStatus_old";
+ALTER TABLE "Book" ALTER COLUMN "status" SET DEFAULT 'planned';
+COMMIT;
+
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_bookId_fkey";
+
+-- AlterTable
+ALTER TABLE "Book" DROP COLUMN "currentPage",
+DROP COLUMN "pageCount",
+ADD COLUMN     "finishedAt" TIMESTAMP(3),
+ADD COLUMN     "format" "FormatParent",
+ADD COLUMN     "formatSubtype" "FormatSubtype",
+ADD COLUMN     "isbn" TEXT,
+ADD COLUMN     "plannedMonth" TEXT,
+ADD COLUMN     "series" TEXT,
+ADD COLUMN     "seriesType" "SeriesType",
+ADD COLUMN     "startedAt" TIMESTAMP(3),
+ALTER COLUMN "author" SET NOT NULL,
+ALTER COLUMN "status" SET DEFAULT 'planned';
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN     "pages" INTEGER,
+ALTER COLUMN "minutes" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "Book_author_idx" ON "Book"("author");
+
+-- CreateIndex
+CREATE INDEX "Book_genre_idx" ON "Book"("genre");
+
+-- CreateIndex
+CREATE INDEX "Book_series_idx" ON "Book"("series");
+
+-- CreateIndex
+CREATE INDEX "Book_plannedMonth_idx" ON "Book"("plannedMonth");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/src/modules/books/books.controller.ts
+++ b/server/src/modules/books/books.controller.ts
@@ -1,0 +1,71 @@
+import type { Request, Response, NextFunction } from "express";
+import { sendCreated, sendNoContent, sendOk } from "../../utils/http";
+import {
+  BookListResponseSchema,
+  BookResponseSchema,
+} from "../../modules/books/books.schema";
+import { createBook, deleteBook, listBooks, updateBook } from "./books.service";
+import {
+  toBookListResponse,
+  toBookResponse,
+} from "../../modules/books/books.mapper";
+
+export async function getBooksHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const query = (req as any).validatedQuery ?? {};
+    const books = await listBooks(query);
+    const response = BookListResponseSchema.parse(toBookListResponse(books));
+    sendOk(res, response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function createBookHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const body = (req as any).validatedBody;
+    const created = await createBook(body);
+    const response = BookResponseSchema.parse(toBookResponse(created));
+    sendCreated(res, response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function updateBookHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const { id } = (req as any).validatedParams as { id: string };
+    const body = (req as any).validatedBody;
+    const updated = await updateBook(id, body);
+    const response = BookResponseSchema.parse(toBookResponse(updated));
+    sendOk(res, response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function deleteBookHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const { id } = (req as any).validatedParams as { id: string };
+    await deleteBook(id);
+    sendNoContent(res);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/server/src/modules/books/books.mapper.ts
+++ b/server/src/modules/books/books.mapper.ts
@@ -1,0 +1,26 @@
+import type { Book } from "@prisma/client";
+import type { BookResponse } from "./books.schema";
+
+export function toBookResponse(book: Book): BookResponse {
+  return {
+    id: book.id,
+    title: book.title,
+    author: book.author,
+    status: book.status,
+    genre: book.genre ?? null,
+    series: book.series ?? null,
+    seriesType: book.seriesType ?? null,
+    format: book.format ?? null,
+    formatSubtype: book.formatSubtype ?? null,
+    isbn: book.isbn ?? null,
+    plannedMonth: book.plannedMonth ?? null,
+    startedAt: book.startedAt ? book.startedAt.toISOString() : null,
+    finishedAt: book.finishedAt ? book.finishedAt.toISOString() : null,
+    createdAt: book.createdAt.toISOString(),
+    updatedAt: book.updatedAt.toISOString(),
+  };
+}
+
+export function toBookListResponse(books: Book[]): BookResponse[] {
+  return books.map(toBookResponse);
+}

--- a/server/src/modules/books/books.router.ts
+++ b/server/src/modules/books/books.router.ts
@@ -1,185 +1,28 @@
 import { Router } from "express";
-import { prisma } from "../../db/client";
+import {
+  createBookHandler,
+  deleteBookHandler,
+  getBooksHandler,
+  updateBookHandler,
+} from "../books/books.controller";
+import { validateBody, validateParams, validateQuery } from "../../utils/http";
 import {
   BookIdParamSchema,
-  BookListResponseSchema,
-  BookResponseSchema,
   CreateBookSchema,
   ListBooksQuerySchema,
   UpdateBookSchema,
 } from "./books.schema";
-import {
-  validateBody,
-  validateParams,
-  validateQuery,
-  sendCreated,
-  sendOk,
-} from "../../utils/http";
-import { AppError } from "../../utils/errors";
-import type { Book } from "@prisma/client";
 
 const router = Router();
 
-// GET /api/books
-router.get("/", validateQuery(ListBooksQuerySchema), async (req, res, next) => {
-  try {
-    const { search, status, limit, offset } = (req as any).validatedQuery ?? {};
-
-    const where: any = {};
-
-    if (status) {
-      where.status = status;
-    }
-
-    if (search) {
-      where.OR = [
-        { title: { contains: search, mode: "insensitive" } },
-        { author: { contains: search, mode: "insensitive" } },
-        { genre: { contains: search, mode: "insensitive" } },
-        { series: { contains: search, mode: "insensitive" } },
-        { isbn: { contains: search, mode: "insensitive" } },
-      ];
-    }
-
-    const books = await prisma.book.findMany({
-      where,
-      orderBy: { createdAt: "desc" },
-      skip: offset ?? 0,
-      take: limit ?? 20,
-    });
-
-    const response = BookListResponseSchema.parse(
-      books.map((b: Book) => ({
-        ...b,
-        genre: b.genre ?? null,
-        series: b.series ?? null,
-        seriesType: b.seriesType ?? null,
-        format: b.format ?? null,
-        formatSubtype: b.formatSubtype ?? null,
-        isbn: b.isbn ?? null,
-        plannedMonth: b.plannedMonth ?? null,
-        startedAt: b.startedAt?.toISOString() ?? null,
-        finishedAt: b.finishedAt?.toISOString() ?? null,
-        createdAt: b.createdAt.toISOString(),
-        updatedAt: b.updatedAt.toISOString(),
-      })),
-    );
-
-    sendOk(res, response);
-  } catch (error) {
-    next(error);
-  }
-});
-
-// POST /api/books
-router.post("/", validateBody(CreateBookSchema), async (req, res, next) => {
-  try {
-    const body = (req as any).validatedBody;
-
-    const created = await prisma.book.create({
-      data: {
-        title: body.title,
-        author: body.author,
-        status: body.status,
-        genre: body.genre,
-        series: body.series,
-        seriesType: body.seriesType,
-        format: body.format,
-        formatSubtype: body.formatSubtype,
-        isbn: body.isbn,
-        plannedMonth: body.plannedMonth,
-      },
-    });
-
-    const response = BookResponseSchema.parse({
-      ...created,
-      genre: created.genre ?? null,
-      series: created.series ?? null,
-      seriesType: created.seriesType ?? null,
-      format: created.format ?? null,
-      formatSubtype: created.formatSubtype ?? null,
-      isbn: created.isbn ?? null,
-      plannedMonth: created.plannedMonth ?? null,
-      startedAt: created.startedAt?.toISOString() ?? null,
-      finishedAt: created.finishedAt?.toISOString() ?? null,
-      createdAt: created.createdAt.toISOString(),
-      updatedAt: created.updatedAt.toISOString(),
-    });
-
-    sendCreated(res, response);
-  } catch (error) {
-    next(error);
-  }
-});
-
-// PATCH /api/books/:id
+router.get("/", validateQuery(ListBooksQuerySchema), getBooksHandler);
+router.post("/", validateBody(CreateBookSchema), createBookHandler);
 router.patch(
   "/:id",
   validateParams(BookIdParamSchema),
   validateBody(UpdateBookSchema),
-  async (req, res, next) => {
-    try {
-      const { id } = (req as any).validatedParams as { id: string };
-      const body = (req as any).validatedBody;
-
-      const existing = await prisma.book.findUnique({ where: { id } });
-      if (!existing) {
-        throw new AppError("Book not found", {
-          status: 404,
-          code: "NOT_FOUND",
-        });
-      }
-
-      const updated = await prisma.book.update({
-        where: { id },
-        data: body,
-      });
-
-      const response = BookResponseSchema.parse({
-        ...updated,
-        genre: updated.genre ?? null,
-        series: updated.series ?? null,
-        seriesType: updated.seriesType ?? null,
-        format: updated.format ?? null,
-        formatSubtype: updated.formatSubtype ?? null,
-        isbn: updated.isbn ?? null,
-        plannedMonth: updated.plannedMonth ?? null,
-        startedAt: updated.startedAt?.toISOString() ?? null,
-        finishedAt: updated.finishedAt?.toISOString() ?? null,
-        createdAt: updated.createdAt.toISOString(),
-        updatedAt: updated.updatedAt.toISOString(),
-      });
-
-      sendOk(res, response);
-    } catch (error) {
-      next(error);
-    }
-  },
+  updateBookHandler,
 );
-
-// DELETE /api/books/:id
-router.delete(
-  "/:id",
-  validateParams(BookIdParamSchema),
-  async (req, res, next) => {
-    try {
-      const { id } = (req as any).validatedParams as { id: string };
-
-      const existing = await prisma.book.findUnique({ where: { id } });
-      if (!existing) {
-        throw new AppError("Book not found", {
-          status: 404,
-          code: "NOT_FOUND",
-        });
-      }
-
-      await prisma.book.delete({ where: { id } });
-
-      sendOk(res, { id });
-    } catch (error) {
-      next(error);
-    }
-  },
-);
+router.delete("/:id", validateParams(BookIdParamSchema), deleteBookHandler);
 
 export { router as booksRouter };

--- a/server/src/modules/books/books.schema.ts
+++ b/server/src/modules/books/books.schema.ts
@@ -11,109 +11,191 @@ export const SeriesTypeSchema = z.enum(SeriesType);
 export const FormatParentSchema = z.enum(FormatParent);
 export const FormatSubtypeSchema = z.enum(FormatSubtype);
 
-const MonthSchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}$/, "plannedMonth must be in YYYY-MM format");
-
-const BookBaseSchema = z.object({
-  title: z
+const trimmedRequiredString = (field: string, max: number) =>
+  z
     .string()
-    .min(1, "Title is required")
-    .max(200, "Title must be at most 200 characters"),
+    .trim()
+    .min(1, `${field} is required`)
+    .max(max, `${field} must be at most ${max} characters`);
 
-  author: z
-    .string()
-    .min(1, "Author is required")
-    .max(120, "Author must be at most 120 characters"),
+const optionalTrimmedNullableString = (field: string, max: number) =>
+  z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (value == null) return undefined;
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? undefined : trimmed;
+    })
+    .refine(
+      (value) => value === undefined || value.length <= max,
+      `${field} must be at most ${max} characters`,
+    );
 
-  genre: z
-    .string()
-    .min(1, "Genre cannot be empty")
-    .max(80, "Genre must be at most 80 characters")
-    .optional()
-    .or(z.literal("").transform(() => undefined)),
+const isbnSchema = z
+  .union([z.string(), z.null(), z.undefined()])
+  .transform((value) => {
+    if (value == null) return undefined;
+    const normalized = value.replace(/[-\s]/g, "").trim();
+    return normalized.length === 0 ? undefined : normalized;
+  })
+  .refine(
+    (value) => value === undefined || value.length <= 32,
+    "ISBN must be at most 32 characters",
+  );
 
-  series: z
-    .string()
-    .min(1, "Series cannot be empty")
-    .max(120, "Series must be at most 120 characters")
-    .optional()
-    .or(z.literal("").transform(() => undefined)),
+const plannedMonthSchema = z
+  .union([z.string(), z.null(), z.undefined()])
+  .transform((value) => {
+    if (value == null) return undefined;
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? undefined : trimmed;
+  })
+  .refine(
+    (value) => value === undefined || /^\d{4}-(0[1-9]|1[0-2])$/.test(value),
+    "plannedMonth must be in YYYY-MM format",
+  );
 
+const BookCreateBaseSchema = z.object({
+  title: trimmedRequiredString("Title", 200),
+  author: trimmedRequiredString("Author", 120),
+
+  status: BookStatusSchema.optional().default(BookStatus.planned),
+
+  genre: optionalTrimmedNullableString("Genre", 80),
+  series: optionalTrimmedNullableString("Series", 120),
   seriesType: SeriesTypeSchema.optional(),
-
   format: FormatParentSchema.optional(),
-
   formatSubtype: FormatSubtypeSchema.optional(),
-
-  isbn: z
-    .string()
-    .min(1, "ISBN cannot be empty")
-    .max(32, "ISBN must be at most 32 characters")
-    .optional()
-    .or(z.literal("").transform(() => undefined)),
-
-  plannedMonth: MonthSchema.optional().or(
-    z.literal("").transform(() => undefined),
-  ),
-
-  status: BookStatusSchema.optional(),
+  isbn: isbnSchema,
+  plannedMonth: plannedMonthSchema,
 });
 
-export const CreateBookSchema = BookBaseSchema.transform((data) => ({
-  ...data,
-  status: data.status ?? BookStatus.planned,
-}));
+export const CreateBookSchema = BookCreateBaseSchema.superRefine(
+  (data, ctx) => {
+    if (data.formatSubtype) {
+      const isDigitalSubtype =
+        data.formatSubtype === FormatSubtype.ebook ||
+        data.formatSubtype === FormatSubtype.Audiobook ||
+        data.formatSubtype === FormatSubtype.PDF;
 
-export const UpdateBookSchema = BookBaseSchema.partial().refine(
-  (data) => Object.keys(data).length > 0,
-  "At least one field must be provided to update a book",
+      const isPhysicalSubtype =
+        data.formatSubtype === FormatSubtype.Hardcover ||
+        data.formatSubtype === FormatSubtype.Paperback;
+
+      if (data.format === FormatParent.digital && isPhysicalSubtype) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["formatSubtype"],
+          message: "formatSubtype does not match format=digital",
+        });
+      }
+
+      if (data.format === FormatParent.physical && isDigitalSubtype) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["formatSubtype"],
+          message: "formatSubtype does not match format=physical",
+        });
+      }
+    }
+  },
 );
+
+export const UpdateBookSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+    author: z.string().trim().min(1).max(120).optional(),
+    status: BookStatusSchema.optional(),
+
+    genre: optionalTrimmedNullableString("Genre", 80),
+    series: optionalTrimmedNullableString("Series", 120),
+    seriesType: SeriesTypeSchema.nullable().optional(),
+    format: FormatParentSchema.nullable().optional(),
+    formatSubtype: FormatSubtypeSchema.nullable().optional(),
+    isbn: isbnSchema,
+    plannedMonth: plannedMonthSchema,
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "At least one field must be provided to update a book",
+  })
+  .superRefine((data, ctx) => {
+    if (data.formatSubtype) {
+      const isDigitalSubtype =
+        data.formatSubtype === FormatSubtype.ebook ||
+        data.formatSubtype === FormatSubtype.Audiobook ||
+        data.formatSubtype === FormatSubtype.PDF;
+
+      const isPhysicalSubtype =
+        data.formatSubtype === FormatSubtype.Hardcover ||
+        data.formatSubtype === FormatSubtype.Paperback;
+
+      if (data.format === FormatParent.digital && isPhysicalSubtype) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["formatSubtype"],
+          message: "formatSubtype does not match format=digital",
+        });
+      }
+
+      if (data.format === FormatParent.physical && isDigitalSubtype) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["formatSubtype"],
+          message: "formatSubtype does not match format=physical",
+        });
+      }
+    }
+  });
 
 export const BookIdParamSchema = z.object({
   id: z.cuid("Invalid book id"),
 });
 
-export const ListBooksQuerySchema = z
-  .object({
-    search: z.string().min(1).max(200).optional(),
-    status: BookStatusSchema.optional(),
+export const ListBooksQuerySchema = z.object({
+  search: z.string().trim().min(1).max(200).optional(),
+  status: BookStatusSchema.optional(),
 
-    limit: z
-      .string()
-      .optional()
-      .transform((v) =>
-        v === undefined || v === "" ? undefined : Number.parseInt(v, 10),
-      )
-      .refine(
-        (v) => v === undefined || (Number.isFinite(v) && v >= 1 && v <= 100),
-        { message: "limit must be between 1 and 100" },
-      ),
+  limit: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value === undefined || value === ""
+        ? undefined
+        : Number.parseInt(value, 10),
+    )
+    .refine(
+      (value) =>
+        value === undefined ||
+        (Number.isInteger(value) && value >= 1 && value <= 100),
+      { message: "limit must be between 1 and 100" },
+    ),
 
-    offset: z
-      .string()
-      .optional()
-      .transform((v) =>
-        v === undefined || v === "" ? undefined : Number.parseInt(v, 10),
-      )
-      .refine((v) => v === undefined || (Number.isFinite(v) && v >= 0), {
-        message: "offset must be >= 0",
-      }),
-  })
-  .partial();
+  offset: z
+    .string()
+    .optional()
+    .transform((value) =>
+      value === undefined || value === ""
+        ? undefined
+        : Number.parseInt(value, 10),
+    )
+    .refine(
+      (value) => value === undefined || (Number.isInteger(value) && value >= 0),
+      { message: "offset must be >= 0" },
+    ),
+});
 
 export const BookResponseSchema = z.object({
   id: z.cuid(),
   title: z.string(),
   author: z.string(),
+  status: BookStatusSchema,
   genre: z.string().nullable(),
   series: z.string().nullable(),
   seriesType: SeriesTypeSchema.nullable(),
   format: FormatParentSchema.nullable(),
   formatSubtype: FormatSubtypeSchema.nullable(),
   isbn: z.string().nullable(),
-  plannedMonth: z.string().nullable(),
-  status: BookStatusSchema,
+  plannedMonth: plannedMonthSchema.nullable(),
   startedAt: z.iso.datetime().nullable(),
   finishedAt: z.iso.datetime().nullable(),
   createdAt: z.iso.datetime(),

--- a/server/src/modules/books/books.service.ts
+++ b/server/src/modules/books/books.service.ts
@@ -1,0 +1,219 @@
+import {
+  BookStatus,
+  FormatParent,
+  FormatSubtype,
+  type Prisma,
+} from "@prisma/client";
+import { prisma } from "../../db/client";
+import { AppError } from "../../utils/errors";
+import type { CreateBookInput, UpdateBookInput } from "./books.schema";
+
+type ListBooksOptions = {
+  search?: string;
+  status?: BookStatus;
+  limit?: number;
+  offset?: number;
+};
+
+function assertFormatConsistency(input: {
+  format?: FormatParent | null;
+  formatSubtype?: FormatSubtype | null;
+}) {
+  const { format, formatSubtype } = input;
+
+  if (!formatSubtype || !format) return;
+
+  const digitalSubtypes = new Set<FormatSubtype>([
+    FormatSubtype.ebook,
+    FormatSubtype.Audiobook,
+    FormatSubtype.PDF,
+  ]);
+
+  const physicalSubtypes = new Set<FormatSubtype>([
+    FormatSubtype.Hardcover,
+    FormatSubtype.Paperback,
+  ]);
+
+  if (format === FormatParent.digital && physicalSubtypes.has(formatSubtype)) {
+    throw new AppError("Validation failed", {
+      status: 400,
+      code: "VALIDATION_ERROR",
+      details: {
+        formatSubtype: ["formatSubtype does not match format=digital"],
+      },
+    });
+  }
+
+  if (format === FormatParent.physical && digitalSubtypes.has(formatSubtype)) {
+    throw new AppError("Validation failed", {
+      status: 400,
+      code: "VALIDATION_ERROR",
+      details: {
+        formatSubtype: ["formatSubtype does not match format=physical"],
+      },
+    });
+  }
+}
+
+function resolveTimestapsForCreate(status: BookStatus) {
+  const now = new Date();
+
+  if (status === BookStatus.planned) {
+    return {
+      startedAt: null,
+      finishedAt: null,
+    };
+  }
+
+  if (status === BookStatus.reading) {
+    return {
+      startedAt: now,
+      finishedAt: null,
+    };
+  }
+  return {
+    startedAt: now,
+    finishedAt: now,
+  };
+}
+
+function resolveTimestapsForUpdate(
+  existing: {
+    status: BookStatus;
+    startedAt: Date | null;
+    finishedAt: Date | null;
+  },
+  nextStatus: BookStatus,
+) {
+  const now = new Date();
+
+  if (nextStatus === BookStatus.planned) {
+    return {
+      startedAt: null,
+      finishedAt: null,
+    };
+  }
+
+  if (nextStatus === BookStatus.reading) {
+    return {
+      startedAt: existing.startedAt ?? now,
+      finishedAt: null,
+    };
+  }
+
+  return {
+    startedAt: existing.startedAt ?? now,
+    finishedAt: existing.finishedAt ?? now,
+  };
+}
+
+export async function listBooks(options: ListBooksOptions) {
+  const { search, status, limit, offset } = options;
+
+  const where: Prisma.BookWhereInput = {};
+
+  if (status) {
+    where.status = status;
+  }
+
+  if (search) {
+    where.OR = [
+      { title: { contains: search, mode: "insensitive" } },
+      { author: { contains: search, mode: "insensitive" } },
+      { genre: { contains: search, mode: "insensitive" } },
+      { series: { contains: search, mode: "insensitive" } },
+      { isbn: { contains: search, mode: "insensitive" } },
+    ];
+  }
+
+  return prisma.book.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    skip: offset ?? 0,
+    take: limit ?? 20,
+  });
+}
+
+export async function createBook(input: CreateBookInput) {
+  assertFormatConsistency({
+    format: input.format,
+    formatSubtype: input.formatSubtype,
+  });
+
+  const timestamps = resolveTimestapsForCreate(input.status);
+
+  return prisma.book.create({
+    data: {
+      title: input.title,
+      author: input.author,
+      status: input.status,
+      genre: input.genre,
+      series: input.series,
+      seriesType: input.seriesType,
+      format: input.format,
+      formatSubtype: input.formatSubtype,
+      isbn: input.isbn,
+      plannedMonth: input.plannedMonth,
+      startedAt: timestamps.startedAt,
+      finishedAt: timestamps.finishedAt,
+    },
+  });
+}
+
+export async function updateBook(id: string, input: UpdateBookInput) {
+  const existing = await prisma.book.findUnique({
+    where: { id },
+  });
+
+  if (!existing) {
+    throw new AppError("Book not found", {
+      status: 404,
+      code: "NOT_FOUND",
+    });
+  }
+
+  const nextFormat =
+    input.format === undefined ? existing.format : input.format;
+  const nextFormatSubtype =
+    input.formatSubtype === undefined
+      ? existing.formatSubtype
+      : input.formatSubtype;
+
+  assertFormatConsistency({
+    format: nextFormat,
+    formatSubtype: nextFormatSubtype,
+  });
+
+  const nextStatus = input.status ?? existing.status;
+  const statusChanged =
+    input.status !== undefined && input.status !== existing.status;
+
+  const timestampPatch = statusChanged
+    ? resolveTimestapsForUpdate(existing, nextStatus)
+    : {};
+
+  return prisma.book.update({
+    where: { id },
+    data: {
+      ...input,
+      ...timestampPatch,
+    },
+  });
+}
+
+export async function deleteBook(id: string) {
+  const existing = await prisma.book.findUnique({
+    where: { id },
+  });
+
+  if (!existing) {
+    throw new AppError("Book not found", {
+      status: 404,
+      code: "NOT_FOUND",
+    });
+  }
+
+  await prisma.book.delete({
+    where: { id },
+  });
+}

--- a/server/src/modules/books/books.timestamp.ts
+++ b/server/src/modules/books/books.timestamp.ts
@@ -1,0 +1,33 @@
+import { BookStatus, type Prisma } from "@prisma/client";
+
+type ExistingBookTimestamps = {
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  status: BookStatus;
+};
+
+export function resolveBookStatusTimestamps(
+  existing: ExistingBookTimestamps | null,
+  nextStatus: BookStatus,
+): Pick<Prisma.BookUncheckedCreateInput, "startedAt" | "finishedAt"> {
+  const now = new Date();
+
+  if (nextStatus === BookStatus.planned) {
+    return {
+      startedAt: null,
+      finishedAt: null,
+    };
+  }
+
+  if (nextStatus === BookStatus.reading) {
+    return {
+      startedAt: existing?.startedAt ?? now,
+      finishedAt: null,
+    };
+  }
+
+  return {
+    startedAt: existing?.startedAt ?? now,
+    finishedAt: existing?.finishedAt ?? now,
+  };
+}

--- a/server/src/modules/sessions/sessions.schema.ts
+++ b/server/src/modules/sessions/sessions.schema.ts
@@ -66,7 +66,7 @@ const SessionBaseSchema = z
     }
   });
 
-export const CreateSessionSchema = SessionBaseSchema.extend({
+export const CreateSessionSchema = SessionBaseSchema.safeExtend({
   bookId: z.cuid("Invalid book id"),
 });
 

--- a/server/src/utils/errors.ts
+++ b/server/src/utils/errors.ts
@@ -28,10 +28,9 @@ export class AppError extends Error {
 }
 
 export function zodToAppError(error: ZodError): AppError {
-  const formatted = error.format();
   return new AppError("Validation failed", {
     status: 400,
     code: "VALIDATION_ERROR",
-    details: formatted,
+    details: error.format(),
   });
 }

--- a/server/src/utils/http.ts
+++ b/server/src/utils/http.ts
@@ -61,11 +61,15 @@ export function validateParams(schema: ZodTypeAny) {
 }
 
 export function sendOk(res: Response, data: unknown) {
-  res.status(200).json({ ok: true, data });
+  return res.status(200).json({ ok: true, data });
 }
 
 export function sendCreated(res: Response, data: unknown) {
-  res.status(201).json({ ok: true, data });
+  return res.status(201).json({ ok: true, data });
+}
+
+export function sendNoContent(res: Response) {
+  return res.status(204).send();
 }
 
 /**


### PR DESCRIPTION
## Summary
Locks the Books API contract for Readr v2.2 ahead of frontend migration.

## What changed
- implemented stable Books CRUD endpoints
- split Books validation into create, update, params, query, and response schemas
- added DTO mapping for consistent API responses
- added Books service layer for Prisma persistence
- locked status transition timestamp behavior for planned, reading, and finished
- standardized delete behavior to `204 No Content`
- verified API behavior through Postman contract testing

## Verified
- `GET /api/books`
- `POST /api/books`
- `PATCH /api/books/:id` metadata updates
- `PATCH /api/books/:id` status transitions
- `DELETE /api/books/:id`
- invalid payload handling
- missing resource handling
- Prisma persistence and migration sync

## Notes
- fixed Zod v4 sessions schema startup issue by replacing `.extend()` with `.safeExtend()` on a refined object schema
- synced Prisma schema/database after local contract drift surfaced during testing