### PR TITLE
Readr v2.2 Sprint 5 — Cleanup, Hardening & Release Lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v2.2.0] — API Persistence Migration (2026-03-19)
+
+### Added
+
+- API-backed persistence for Books and Sessions
+- Unified request handling across client service layer
+- Export backup system using live API data
+
+### Changed
+
+- Migrated from localStorage to Express + PostgreSQL persistence
+- Standardized error handling and API response validation
+- Updated Settings page messaging for backup system
+- README updated to reflect API-backed architecture
+
+### Removed
+
+- Legacy localStorage persistence for Books and Sessions
+- Obsolete storage adapters and dead persistence helpers
+- Dual persistence pathways (client vs server)
+
+### Fixed
+
+- Inconsistent service layer behavior between Books and Sessions
+- Edge cases in undo behavior under API persistence
+- Stale assumptions tied to local-first architecture
+
+### Notes
+
+- Backup import is temporarily disabled and will return in v2.3
+- v2.2 marks completion of the local-first → API migration
+
+---
+
 ## [v2.2.0-sprint-4] — Sessions Persistence Migration (2026-03-17)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A versioned full-stack reading tracker built to demonstrate modern frontend arch
   <img src="https://img.shields.io/github/actions/workflow/status/conorgregson/readr-v2/ci.yml?style=for-the-badge&label=CI&logo=github" />
 </a>
 
-<img src="https://img.shields.io/badge/Status-v2.2%20In%20Development-orange?style=for-the-badge" />
+<img src="https://img.shields.io/badge/Status-v2.2%20Ready%20for%20Release-4CAF50?style=for-the-badge" />
 <img src="https://img.shields.io/badge/Commits-Signed%20(Verified)-00C853?style=for-the-badge&logo=github" />
 
 </p>
@@ -34,14 +34,20 @@ A versioned full-stack reading tracker built to demonstrate modern frontend arch
 
 ## Live Demo
 
-Try the deployed frontend here:
+Try the deployed full-stack app here:
 
-https://readr-v2-app.vercel.app
+**▶** https://readr-v2-app.vercel.app
 
-The demo currently runs **client-side only** using localStorage.
-Your reading data is stored in your browser and will persist until site data is cleared. This reflects the **v2.1 parity release**.
+The demo is now connected to the **Express + PostgreSQL backend**, with all reading data persisted via the API.
 
-Server-backed persistence will be introduced in **v2.2**, connecting the deployed UI to the API layer.
+### Notes
+
+- Data is now **server-backed (v2.2)** instead of localStorage
+- Changes (add/edit/delete) persist across sessions and devices
+- **Backup export is supported**
+- **Backup import is temporarily disabled** during the persistence migration (planned for v2.3 via a safe bulk-import endpoint)
+
+> v2.2 marks the transition from local-first storage to a fully API-backed architecture.
 
 ---
 
@@ -61,7 +67,7 @@ Each version isolates a specific risk area (architecture, UX, persistence, or sc
 The original v1.x app remains available here:
 **▶** https://github.com/conorgregson/reading-log-app
 
-> Current focus: **v2.2 — API integration & persistence.**
+> Current focus: **v2.2 — API-backed persistence (release-ready).**
 
 ---
 
@@ -79,7 +85,12 @@ Readr v2 was designed to demonstrate several real-world frontend engineering pat
   Critical actions (delete / finish) support ~6s undo windows while preserving filters, search state, and list ordering.
 
 - **Local-First → API Migration Strategy**
-  v2.1 intentionally keeps local persistence while the backend is built, allowing UI parity to stabilize before switching to API-backed storage in v2.2.
+  Readr evolved through a staged migration to reduce system-wide risk:
+  - v1.x: fully offline-first (localStorage)
+  - v2.1: React rebuild maintained local persistence for parity lock
+  - v2.2: full migration to API-backed persistence (Express + PostgreSQL)
+
+  This approach ensured UI behavior remained stable while replacing the underlying data layer.
 
 - **CI-Gated Development**
   GitHub Actions enforces typecheck, lint, and test validation on every push and pull request.
@@ -338,8 +349,8 @@ readr-v2/
                      └─────────────┬────────────┘
                                    │
                                    ▼
-                      Client Services Layer (v2.1)
-                        local-first persistence
+                          Client Services Layer
+                      API-backed persistence (v2.2)
 
                                    │
                                    ▼
@@ -374,7 +385,7 @@ readr-v2/
 flowchart TD
 
 A[React Frontend<br/>Vite + TypeScript + Tailwind]
-  --> B[Client Services Layer<br/>local-first in v2.1]
+  --> B[Client Services Layer<br/>API-backed (v2.2)]
 
 B -->|v2.2+| C[Express Server<br/>Node + TypeScript]
 
@@ -441,9 +452,7 @@ Engineering choices are documented to emphasize maintainability and long-term sc
 
 ## Screenshots
 
-The UI below reflects the **v2.1 React parity release**.
-
-> Screenshots will be updated again once API persistence (v2.2) lands.
+The UI below reflects the **v2.2 full-stack release** with API-backed persistence.
 
 - Dashboard _(coming soon)_
 - Library / Book List _(coming soon)_

--- a/client/scripts/gen-backup.mjs
+++ b/client/scripts/gen-backup.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 const OUTPUT_DIR = path.resolve(process.cwd(), "scripts", "out");
-const OUTPUT_FILE = path.join(OUTPUT_DIR, "readr-backup-v2.1-seed.json");
+const OUTPUT_FILE = path.join(OUTPUT_DIR, "readr-backup-v2.2-seed.json");
 
 // Change these counts anytime
 const BOOKS_COUNT = 500;
@@ -202,7 +202,7 @@ function main() {
 
   const backup = {
     app: "readr",
-    version: "2.1",
+    version: "2.2",
     exportedAt: isoNow(),
     books,
     sessions,

--- a/client/src/features/books/page.test.tsx
+++ b/client/src/features/books/page.test.tsx
@@ -56,7 +56,6 @@ function makeBook(overrides: Partial<Book> = {}): Book {
 }
 
 beforeEach(() => {
-  localStorage.clear();
   useBooksStore.getState().reset();
   vi.clearAllMocks();
 });
@@ -65,7 +64,7 @@ describe("BooksPage undo flow", () => {
   it("restores a deleted book when Undo is clicked", async () => {
     const user = userEvent.setup();
 
-    vi.mocked(BooksService.remove).mockResolvedValue(true);
+    vi.mocked(BooksService.remove).mockResolvedValue(undefined);
 
     useBooksStore.setState({
       isBootstrapped: true,

--- a/client/src/features/books/services/books.service.ts
+++ b/client/src/features/books/services/books.service.ts
@@ -7,7 +7,9 @@ import type {
   SeriesType,
 } from "../types";
 
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:4000/api";
+const API_BASE =
+  import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, "") ??
+  "http://localhost:4000";
 
 type ApiEnvelope<T> = {
   ok: boolean;
@@ -91,7 +93,7 @@ function sanitizeNullableString(value: unknown): string | null | undefined {
 }
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const url = `${API_BASE}${path}`;
+  const url = `${API_BASE}/api${path}`;
 
   const response = await fetch(url, {
     headers: {
@@ -226,7 +228,7 @@ export const BooksService = {
     return toClientBook(created);
   },
 
-  async update(id: BookId, patch: UpdateBookInput): Promise<Book | null> {
+  async update(id: BookId, patch: UpdateBookInput): Promise<Book> {
     const updated = await request<ApiBook>(`/books/${id}`, {
       method: "PATCH",
       body: JSON.stringify(normalizeUpdateInput(patch)),
@@ -235,11 +237,9 @@ export const BooksService = {
     return toClientBook(updated);
   },
 
-  async remove(id: BookId): Promise<boolean> {
+  async remove(id: BookId): Promise<void> {
     await request<void>(`/books/${id}`, {
       method: "DELETE",
     });
-
-    return true;
   },
 };

--- a/client/src/features/books/store/books.store.ts
+++ b/client/src/features/books/store/books.store.ts
@@ -62,7 +62,7 @@ type BooksState = {
   // domain
   books: Book[];
 
-  // undo (Sprint 5)
+  // undo
   undo: UndoRecord | null;
   undoLast: () => Promise<boolean>;
   clearUndo: () => void;
@@ -118,7 +118,7 @@ const initialState: Pick<
   isBootstrapped: false,
   isLoading: false,
 
-  // Sprint 2: server-backed books list
+  // server-backed books list
   books: [],
 
   filters: defaultBooksFilters(),
@@ -206,7 +206,6 @@ export const useBooksStore = create<BooksState>((set, get) => ({
       set({ books: next, page: { mode: "results" } });
 
       const saved = await BooksService.update(id, persistPatch);
-      if (!saved) throw new Error("Book not found");
 
       // Sync store to persisted record
       set((s) => ({
@@ -315,8 +314,6 @@ export const useBooksStore = create<BooksState>((set, get) => ({
         status: "finished",
         ...(prev.finishedAt ? {} : { finishedAt: nowIso }),
       });
-
-      if (!saved) throw new Error("Book not found");
 
       set((s) => ({
         books: s.books.map((b) => (b.id === id ? saved : b)),

--- a/client/src/features/books/store/books.store.undo.test.ts
+++ b/client/src/features/books/store/books.store.undo.test.ts
@@ -38,7 +38,7 @@ describe("BooksStore Undo (Sprint 5)", () => {
 
     useBooksStore.setState({ books });
 
-    vi.mocked(BooksService.remove).mockResolvedValue(true);
+    vi.mocked(BooksService.remove).mockResolvedValue(undefined);
 
     const ok = await useBooksStore.getState().deleteBook("1");
 
@@ -57,7 +57,7 @@ describe("BooksStore Undo (Sprint 5)", () => {
 
     useBooksStore.setState({ books });
 
-    vi.mocked(BooksService.remove).mockResolvedValue(true);
+    vi.mocked(BooksService.remove).mockResolvedValue(undefined);
 
     await useBooksStore.getState().deleteBook("1");
 
@@ -75,7 +75,7 @@ describe("BooksStore Undo (Sprint 5)", () => {
 
     useBooksStore.setState({ books });
 
-    vi.mocked(BooksService.remove).mockResolvedValue(true);
+    vi.mocked(BooksService.remove).mockResolvedValue(undefined);
 
     await useBooksStore.getState().deleteBook("1");
 
@@ -96,7 +96,7 @@ describe("BooksStore Undo (Sprint 5)", () => {
 
     useBooksStore.setState({ books });
 
-    vi.mocked(BooksService.remove).mockResolvedValue(true);
+    vi.mocked(BooksService.remove).mockResolvedValue(undefined);
 
     const ok = await useBooksStore.getState().deleteBook("1");
 
@@ -113,7 +113,7 @@ describe("BooksStore Undo (Sprint 5)", () => {
 
     useBooksStore.setState({ books });
 
-    vi.mocked(BooksService.remove).mockResolvedValue(true);
+    vi.mocked(BooksService.remove).mockResolvedValue(undefined);
 
     await useBooksStore.getState().deleteBook("1");
     await useBooksStore.getState().undoLast();

--- a/client/src/features/sessions/components/SessionsUndoBar.tsx
+++ b/client/src/features/sessions/components/SessionsUndoBar.tsx
@@ -41,9 +41,9 @@ export function SessionsUndoBar() {
       <Button
         ref={undoBtnRef}
         variant="secondary"
-        onClick={() => {
+        onClick={async () => {
           const restoredSessionId = undo.session.id;
-          undoDelete();
+          await undoDelete();
 
           window.setTimeout(() => {
             const row = document.getElementById(

--- a/client/src/features/sessions/services/sessions.service.ts
+++ b/client/src/features/sessions/services/sessions.service.ts
@@ -15,16 +15,28 @@ type ApiEnvelope<T> = {
   data: T;
 };
 
+type ApiErrorEnvelope = {
+  ok?: false;
+  error?: {
+    message?: string;
+    code?: string;
+    details?: unknown;
+  };
+};
+
 type DeleteSessionResponse = {
   id: string;
 };
 
 async function readJson<T>(res: Response): Promise<T> {
-  const json = (await res.json().catch(() => null)) as T | null;
+  const json = (await res.json().catch(() => null)) as
+    | T
+    | ApiErrorEnvelope
+    | null;
 
   if (!res.ok) {
     const message =
-      (json as { error?: { message?: string } } | null)?.error?.message ??
+      (json as ApiErrorEnvelope | null)?.error?.message ??
       `Request failed (${res.status})`;
     throw new Error(message);
   }
@@ -33,7 +45,7 @@ async function readJson<T>(res: Response): Promise<T> {
     throw new Error("Invalid server response.");
   }
 
-  return json;
+  return json as T;
 }
 
 export const SessionsService = {

--- a/client/src/features/sessions/store/sessions.store.ts
+++ b/client/src/features/sessions/store/sessions.store.ts
@@ -113,6 +113,7 @@ type SessionsState = {
   reset: () => void;
 };
 
+// UI-only persistence: view preferences survive refresh, but session data is API-backed.
 const persistedUI = safeParse<{
   filters?: SessionsFilters;
   sortKey?: SessionsSortKey;

--- a/client/src/features/settings/page.tsx
+++ b/client/src/features/settings/page.tsx
@@ -7,21 +7,12 @@ import {
   importBackup,
   downloadJson,
 } from "../../shared/data/backup";
-import { useBooksStore } from "../books/store/books.store";
-import { useSessionsStore } from "../sessions/store/sessions.store";
 
 export function SettingsPage() {
   const [status, setStatus] = useState<string>("");
   const [error, setError] = useState<string>("");
 
   const fileRef = useRef<HTMLInputElement | null>(null);
-
-  const loadBooks = useBooksStore((s) => s.loadBooks);
-  const loadSessions = useSessionsStore((s) => s.loadSessions);
-
-  async function refresh() {
-    await Promise.all([loadBooks(), loadSessions()]);
-  }
 
   return (
     <div className="space-y-4">
@@ -31,8 +22,8 @@ export function SettingsPage() {
         <div className="space-y-2">
           <h2 className="text-sm font-semibold">Data</h2>
           <p className="text-sm text-slate-500">
-            Import/export your local data as JSON. This is the fastest way to
-            load hundreds of books and sessions.
+            Export your current data as JSON. Backup import is temporarily
+            unavailable during the API persistence migration.
           </p>
 
           {status ? (
@@ -55,7 +46,7 @@ export function SettingsPage() {
 
                 const data = await exportBackup();
                 const stamp = data.exportedAt.slice(0, 10);
-                downloadJson(`readr-backup-v2.1-${stamp}.json`, data);
+                downloadJson(`readr-backup-v2.2-${stamp}.json`, data);
 
                 setStatus(
                   `Exported ${data.books.length} books and ${data.sessions.length} sessions.`,
@@ -67,11 +58,8 @@ export function SettingsPage() {
 
             <Button
               variant="secondary"
-              onClick={() => {
-                setError("");
-                setStatus("");
-                fileRef.current?.click();
-              }}
+              disabled
+              title="Import is temporarily unavailable in v2.2"
             >
               Import JSON
             </Button>
@@ -83,25 +71,18 @@ export function SettingsPage() {
               className="hidden"
               onChange={async (e) => {
                 const file = e.target.files?.[0] ?? null;
-                e.target.value = ""; // allow re-importing same file
+                e.target.value = "";
                 if (!file) return;
 
                 setError("");
-                setStatus("Importing…");
+                setStatus("");
 
                 try {
                   const text = await file.text();
-                  const parsed = JSON.parse(text);
+                  JSON.parse(text); // validate JSON file shape at a basic level
 
-                  const res = await importBackup(parsed);
-                  await refresh();
-
-                  setStatus(
-                    `Imported ${res.books.length} books and ${res.sessions.length} sessions. ` +
-                      `Dropped: ${res.dropped.books} book item(s), ${res.dropped.sessions} session item(s).`,
-                  );
+                  await importBackup();
                 } catch (err) {
-                  setStatus("");
                   setError((err as Error)?.message ?? "Import failed.");
                 }
               }}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -22,18 +22,7 @@ class ErrorBoundary extends React.Component<
         <pre style={{ whiteSpace: "pre-wrap" }}>
           {String(this.state.error.stack || this.state.error.message)}
         </pre>
-        <button
-          onClick={() => {
-            try {
-              localStorage.clear();
-            } catch {
-              // ignore
-            }
-            location.reload();
-          }}
-        >
-          Clear storage & reload
-        </button>
+        <button onClick={() => location.reload()}>Reload app</button>
       </div>
     );
   }

--- a/client/src/shared/data/backup.ts
+++ b/client/src/shared/data/backup.ts
@@ -1,39 +1,21 @@
-// TODO(v2.3): Restore backup import support for Sessions through a backend bulk-import endpoint.
-// Sessions are now API-backed, so the old client-side replaceAll flow is intentionally disabled.
-// Re-enable import only after server-side validation, deduplication, and foreign-key-safe bulk writes exist.
+// TODO(v2.3): Restore backup import support through a backend bulk-import endpoint.
+// Sessions are API-backed, so client-side replace-all import remains intentionally disabled.
+// Re-enable only after server-side validation, deduplication, and foreign-key-safe bulk writes exist.
 
 import { BooksService } from "../../features/books/services/books.service";
 import { SessionsService } from "../../features/sessions/services/sessions.service";
 import type { Book } from "../../features/books/types";
 import type { Session } from "../../features/sessions/types";
 
-export type ReadrBackupV21 = {
+export type ReadrBackup = {
   app: "readr";
-  version: "2.1";
+  version: "2.2";
   exportedAt: string; // ISO
   books: Book[];
   sessions: Session[];
 };
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return !!v && typeof v === "object" && !Array.isArray(v);
-}
-
-function asArray(v: unknown): unknown[] {
-  return Array.isArray(v) ? v : [];
-}
-
-function sanitizeBooks(raw: unknown[]): { books: Book[]; dropped: number } {
-  let dropped = 0;
-  const candidates: unknown[] = [];
-  for (const item of raw) {
-    if (item && typeof item === "object") candidates.push(item);
-    else dropped += 1;
-  }
-  return { books: candidates as Book[], dropped };
-}
-
-export async function exportBackup(): Promise<ReadrBackupV21> {
+export async function exportBackup(): Promise<ReadrBackup> {
   const [books, sessions] = await Promise.all([
     BooksService.list(),
     SessionsService.list(),
@@ -41,44 +23,17 @@ export async function exportBackup(): Promise<ReadrBackupV21> {
 
   return {
     app: "readr",
-    version: "2.1",
+    version: "2.2",
     exportedAt: new Date().toISOString(),
     books,
     sessions,
   };
 }
 
-export async function importBackup(raw: unknown): Promise<{
-  books: Book[];
-  sessions: Session[];
-  dropped: { books: number; sessions: number };
-}> {
-  if (!isRecord(raw)) {
-    throw new Error("Invalid backup file (not an object).");
-  }
-
-  const booksRaw = asArray(raw.books);
-  const sessionsRaw = asArray(raw.sessions);
-
-  const booksPre = sanitizeBooks(booksRaw);
-
-  if (booksPre.books.length > 0 || sessionsRaw.length > 0) {
-    throw new Error(
-      "Backup import is temporarily unavailable during the API persistence migration. Export is still supported.",
-    );
-  }
-
-  const books = await BooksService.list();
-  const sessions = await SessionsService.list();
-
-  return {
-    books,
-    sessions,
-    dropped: {
-      books: booksPre.dropped,
-      sessions: 0,
-    },
-  };
+export async function importBackup(): Promise<never> {
+  throw new Error(
+    "Backup import is temporarily unavailable during the API persistence migration. Export is still supported.",
+  );
 }
 
 // Browser download helper


### PR DESCRIPTION
# Readr v2.2 — Sprint 5: Cleanup, Hardening & Release Lock

## Summary

This PR finalizes the v2.2 persistence migration by removing legacy localStorage data flows, standardizing API-backed services, and preparing the project for release.

v2.2 completes the transition from a local-first architecture (v1.x, v2.1) to a fully API-backed system using Express + PostgreSQL.

---

## Highlights

- Full migration to API-backed persistence (Books + Sessions)
- Unified client service layer with consistent request handling
- Removal of legacy localStorage persistence logic
- Backup import safely disabled (pending server-side bulk import in v2.3)
- End-to-end regression validation completed
- Build + CI passing

---

## What’s changed

### Persistence Migration
- Books and Sessions now fully rely on API endpoints
- Removed dual persistence paths (client vs server)
- Ensured single source of truth (database)

### Service Layer Standardization
- Unified request patterns across BooksService and SessionsService
- Consistent error handling and response validation
- Normalization logic centralized and hardened

### Cleanup
- Removed obsolete localStorage adapters and helpers
- Deleted dead code paths and outdated persistence assumptions
- Updated comments to reflect API-first architecture

### Backup System
- Export now pulls directly from API
- Import temporarily disabled to prevent unsafe bulk writes
- Clear UX messaging added in Settings page

### Hardening
- Verified API error handling across client
- Confirmed server response consistency
- Validated undo flows under API persistence

### Regression Validation
- Books flows verified (CRUD, undo, finish)
- Sessions flows verified (CRUD, undo, restore)
- Search, filters, and keyboard navigation confirmed stable

---

## Validation

- All tests passing (unit + component)
- CI pipeline green
- Production build successful
- Manual regression sweep completed

---

## Known Limitations

- Backup import is temporarily disabled
  - Will be reintroduced in v2.3 with:
    - server-side validation
    - deduplication
    - safe bulk insertion

---

## Result

Readr v2.2 is now:

- Fully API-backed
- Behaviorally consistent with v2.1 parity guarantees
- Clean of legacy persistence logic
- Ready for release