### PR TITLE
Readr v2.3 Sprint 2 — Auth UX & Session Persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v2.3.0-sprint-2] — Auth UX & Session Persistence (2026-03-20)
+
+### Added
+
+- Added auth bootstrap loading state in AppShell.
+- Added client-side validation feedback for login and registration forms.
+- Added separate loading states for login and registration actions.
+- Added centralized unauthorized-response handling in the API client.
+
+### Changed
+
+- Improved auth error messaging for invalid credentials and duplicate email cases.
+- Improved session restore flow using `/auth/me` on app load.
+- Hardened token storage reads and writes against browser storage failures.
+- Updated auth page behavior to disable inputs and prevent duplicate submissions during pending requests.
+
+### Removed
+
+- Removed implicit token clearing from the auth service layer in favor of store-controlled session handling.
+
+### Notes
+
+- Sprint 2 completes auth UX polish and session persistence hardening for v2.3.
+- App bootstrap now resolves authentication state before rendering protected UI.
+- Invalid token detection occurs during auth restore and authenticated API requests.
+- Immediate logout after manual same-tab token mutation (e.g., DevTools) is not guaranteed and is out of scope for this sprint.
+- Behavior aligns with standard client-side session validation patterns.
+
+---
+
 ## [v2.3.0-sprint-1] — Auth & Ownership Foundation (2026-03-19)
 
 ### Added

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -14,6 +14,21 @@ function navClass({ isActive }: { isActive: boolean }) {
   ].join(" ");
 }
 
+function AuthBootstrapScreen() {
+  return (
+    <div className="min-h-dvh bg-slate-950 text-slate-100 flex items-center justify-center px-4">
+      <div
+        className="rounded-2xl border border-slate-800 bg-slate-900 px-6 py-5 shadow-xl"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
+        <p className="text-sm text-slate-300">Restoring your session...</p>
+      </div>
+    </div>
+  );
+}
+
 export function AppShell() {
   const user = useAuthStore((s) => s.user);
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -35,11 +50,7 @@ export function AppShell() {
   }
 
   if (isBootstrapping) {
-    return (
-      <div className="min-h-dvh bg-slate-950 text-slate-100 flex items-center justify-center">
-        <div className="text-sm text-slate-400">Loading...</div>
-      </div>
-    );
+    return <AuthBootstrapScreen />;
   }
 
   if (!isAuthenticated) {
@@ -61,7 +72,7 @@ export function AppShell() {
           </div>
 
           <div className="flex items-center gap-3">
-            <nav className="flex items-center gap-1">
+            <nav className="flex items-center gap-1" aria-label="Primary">
               <NavLink to="/" end className={navClass}>
                 Books
               </NavLink>

--- a/client/src/features/auth/page.tsx
+++ b/client/src/features/auth/page.tsx
@@ -1,33 +1,73 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useAuthStore } from "./store/auth.store";
 
 type Mode = "login" | "register";
+
+function isValidEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
 
 export function AuthPage() {
   const login = useAuthStore((s) => s.login);
   const register = useAuthStore((s) => s.register);
   const error = useAuthStore((s) => s.error);
   const clearError = useAuthStore((s) => s.clearError);
+  const isLoginLoading = useAuthStore((s) => s.isLoginLoading);
+  const isRegisterLoading = useAuthStore((s) => s.isRegisterLoading);
 
   const [mode, setMode] = useState<Mode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [touched, setTouched] = useState({
+    email: false,
+    password: false,
+  });
+
+  const isSubmitting = mode === "login" ? isLoginLoading : isRegisterLoading;
+
+  const emailError = useMemo(() => {
+    if (!touched.email) return null;
+    if (!email.trim()) return "Email is required.";
+    if (!isValidEmail(email.trim())) return "Enter a valid email address.";
+    return null;
+  }, [email, touched.email]);
+
+  const passwordError = useMemo(() => {
+    if (!touched.password) return null;
+    if (!password) return "Password is required.";
+    if (password.length < 8) return "Password must be at least 8 characters.";
+    return null;
+  }, [password, touched.password]);
+
+  const formError = emailError || passwordError;
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    clearError();
-    setIsSubmitting(true);
 
-    try {
-      if (mode === "login") {
-        await login({ email, password });
-      } else {
-        await register({ email, password });
-      }
-    } finally {
-      setIsSubmitting(false);
+    setTouched({
+      email: true,
+      password: true,
+    });
+
+    clearError();
+
+    if (formError) return;
+
+    if (mode === "login") {
+      await login({ email, password });
+      return;
     }
+
+    await register({ email, password });
+  }
+
+  function switchMode(nextMode: Mode) {
+    clearError();
+    setTouched({
+      email: false,
+      password: false,
+    });
+    setMode(nextMode);
   }
 
   return (
@@ -48,10 +88,8 @@ export function AuthPage() {
         <div className="mb-4 flex rounded-xl bg-slate-800 p-1">
           <button
             type="button"
-            onClick={() => {
-              clearError();
-              setMode("login");
-            }}
+            onClick={() => switchMode("login")}
+            disabled={isSubmitting}
             className={`flex-1 rounded-lg px-3 py-2 text-sm transition ${
               mode === "login"
                 ? "bg-slate-700 text-slate-50"
@@ -62,10 +100,8 @@ export function AuthPage() {
           </button>
           <button
             type="button"
-            onClick={() => {
-              clearError();
-              setMode("register");
-            }}
+            onClick={() => switchMode("register")}
+            disabled={isSubmitting}
             className={`flex-1 rounded-lg px-3 py-2 text-sm transition ${
               mode === "register"
                 ? "bg-slate-700 text-slate-50"
@@ -76,39 +112,73 @@ export function AuthPage() {
           </button>
         </div>
 
-        <form onSubmit={onSubmit} className="space-y-4">
+        <form onSubmit={onSubmit} className="space-y-4" noValidate>
           <div>
-            <label className="mb-1 block text-sm text-slate-300">Email</label>
+            <label
+              className="mb-1 block text-sm text-slate-300"
+              htmlFor="auth-email"
+            >
+              Email
+            </label>
             <input
+              id="auth-email"
               type="email"
               autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm outline-none ring-0 transition focus:border-teal-500"
+              onBlur={() => setTouched((prev) => ({ ...prev, email: true }))}
+              disabled={isSubmitting}
+              aria-invalid={emailError ? "true" : "false"}
+              aria-describedby={emailError ? "auth-email-error" : undefined}
+              className="w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm outline-none ring-0 transition focus:border-teal-500 disabled:opacity-60"
               placeholder="you@example.com"
               required
             />
+            {emailError ? (
+              <p id="auth-email-error" className="mt-1 text-sm text-red-300">
+                {emailError}
+              </p>
+            ) : null}
           </div>
 
           <div>
-            <label className="mb-1 block text-sm text-slate-300">
+            <label
+              className="mb-1 block text-sm text-slate-300"
+              htmlFor="auth-password"
+            >
               Password
             </label>
             <input
+              id="auth-password"
               type="password"
               autoComplete={
                 mode === "login" ? "current-password" : "new-password"
               }
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm outline-none ring-0 transition focus:border-teal-500"
+              onBlur={() => setTouched((prev) => ({ ...prev, password: true }))}
+              disabled={isSubmitting}
+              aria-invalid={passwordError ? "true" : "false"}
+              aria-describedby={
+                passwordError ? "auth-password-error" : undefined
+              }
+              className="w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm outline-none ring-0 transition focus:border-teal-500 disabled:opacity-60"
               placeholder="At least 8 characters"
               required
             />
+            {passwordError ? (
+              <p id="auth-password-error" className="mt-1 text-sm text-red-300">
+                {passwordError}
+              </p>
+            ) : null}
           </div>
 
           {error ? (
-            <div className="rounded-xl border border-red-900/60 bg-red-950/40 px-3 py-2 text-sm text-red-300">
+            <div
+              className="rounded-xl border border-red-900/60 bg-red-950/40 px-3 py-2 text-sm text-red-300"
+              role="alert"
+              aria-live="polite"
+            >
               {error}
             </div>
           ) : null}

--- a/client/src/features/auth/services/auth.service.ts
+++ b/client/src/features/auth/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { apiFetch, clearToken } from "../../../shared/api/api";
+import { apiFetch } from "../../../shared/api/api";
 
 type ApiEnvelope<T> = {
   ok: boolean;
@@ -13,6 +13,23 @@ type ApiErrorEnvelope = {
     details?: unknown;
   };
 };
+
+export class ApiRequestError extends Error {
+  status: number;
+  code?: string;
+  details?: unknown;
+
+  constructor(
+    message: string,
+    options: { status: number; code?: string; details?: unknown },
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = options.status;
+    this.code = options.code;
+    this.details = options.details;
+  }
+}
 
 export type AuthUser = {
   id: string;
@@ -45,7 +62,14 @@ async function readJson<T>(res: Response): Promise<T> {
         ? (json.error?.message ?? `Request failed (${res.status})`)
         : `Request failed (${res.status})`;
 
-    throw new Error(message);
+    const code = json && "error" in json ? json.error?.code : undefined;
+    const details = json && "error" in json ? json.error?.details : undefined;
+
+    throw new ApiRequestError(message, {
+      status: res.status,
+      code,
+      details,
+    });
   }
 
   if (!json || !("data" in json)) {
@@ -85,12 +109,7 @@ export const AuthService = {
       method: "GET",
     });
 
-    try {
-      const data = await readJson<MeResponse>(res);
-      return data.user;
-    } catch (error) {
-      clearToken();
-      throw error;
-    }
+    const data = await readJson<MeResponse>(res);
+    return data.user;
   },
 };

--- a/client/src/features/auth/store/auth.store.ts
+++ b/client/src/features/auth/store/auth.store.ts
@@ -1,11 +1,22 @@
 import { create } from "zustand";
-import { clearToken, getToken, setToken } from "../../../shared/api/api";
-import { AuthService, type AuthUser } from "../services/auth.service";
+import {
+  clearToken,
+  getToken,
+  setToken,
+  setUnauthorizedHandler,
+} from "../../../shared/api/api";
+import {
+  AuthService,
+  ApiRequestError,
+  type AuthUser,
+} from "../services/auth.service";
 
 type AuthState = {
   user: AuthUser | null;
   isAuthenticated: boolean;
   isBootstrapping: boolean;
+  isLoginLoading: boolean;
+  isRegisterLoading: boolean;
   error: string | null;
 
   setAuth: (data: { token: string; user: AuthUser }) => void;
@@ -16,10 +27,35 @@ type AuthState = {
   logout: () => void;
 };
 
+function mapAuthError(error: unknown, fallback: string) {
+  if (error instanceof ApiRequestError) {
+    if (error.code === "INVALID_CREDENTIALS" || error.status === 401) {
+      return "Email or password is incorrect.";
+    }
+
+    if (
+      error.code === "EMAIL_ALREADY_EXISTS" ||
+      /already exists|duplicate/i.test(error.message)
+    ) {
+      return "An account with that email already exists.";
+    }
+
+    return error.message || fallback;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isAuthenticated: false,
   isBootstrapping: true,
+  isLoginLoading: false,
+  isRegisterLoading: false,
   error: null,
 
   setAuth: ({ token, user }) => {
@@ -28,11 +64,18 @@ export const useAuthStore = create<AuthState>((set) => ({
       user,
       isAuthenticated: true,
       isBootstrapping: false,
+      isLoginLoading: false,
+      isRegisterLoading: false,
       error: null,
     });
   },
 
   login: async ({ email, password }) => {
+    set({
+      isLoginLoading: true,
+      error: null,
+    });
+
     try {
       const data = await AuthService.login({ email, password });
       setToken(data.token);
@@ -40,6 +83,8 @@ export const useAuthStore = create<AuthState>((set) => ({
         user: data.user,
         isAuthenticated: true,
         isBootstrapping: false,
+        isLoginLoading: false,
+        isRegisterLoading: false,
         error: null,
       });
       return true;
@@ -49,13 +94,19 @@ export const useAuthStore = create<AuthState>((set) => ({
         user: null,
         isAuthenticated: false,
         isBootstrapping: false,
-        error: (error as Error)?.message ?? "Login failed",
+        isLoginLoading: false,
+        error: mapAuthError(error, "Login failed. Please try again."),
       });
       return false;
     }
   },
 
   register: async ({ email, password }) => {
+    set({
+      isRegisterLoading: true,
+      error: null,
+    });
+
     try {
       const data = await AuthService.register({ email, password });
       setToken(data.token);
@@ -63,6 +114,8 @@ export const useAuthStore = create<AuthState>((set) => ({
         user: data.user,
         isAuthenticated: true,
         isBootstrapping: false,
+        isLoginLoading: false,
+        isRegisterLoading: false,
         error: null,
       });
       return true;
@@ -72,13 +125,19 @@ export const useAuthStore = create<AuthState>((set) => ({
         user: null,
         isAuthenticated: false,
         isBootstrapping: false,
-        error: (error as Error)?.message ?? "Registration failed",
+        isRegisterLoading: false,
+        error: mapAuthError(error, "Registration failed. Please try again."),
       });
       return false;
     }
   },
 
   restoreAuth: async () => {
+    set({
+      isBootstrapping: true,
+      error: null,
+    });
+
     const token = getToken();
 
     if (!token) {
@@ -118,7 +177,17 @@ export const useAuthStore = create<AuthState>((set) => ({
       user: null,
       isAuthenticated: false,
       isBootstrapping: false,
+      isLoginLoading: false,
+      isRegisterLoading: false,
       error: null,
     });
   },
 }));
+
+setUnauthorizedHandler(() => {
+  const state = useAuthStore.getState();
+
+  if (!state.isAuthenticated && !state.isBootstrapping) return;
+
+  state.logout();
+});

--- a/client/src/shared/api/api.ts
+++ b/client/src/shared/api/api.ts
@@ -4,6 +4,12 @@ const API_BASE =
 
 const TOKEN_KEY = "readr.auth.token";
 
+let unauthorizedHandler: (() => void) | null = null;
+
+export function setUnauthorizedHandler(handler: (() => void) | null) {
+  unauthorizedHandler = handler;
+}
+
 export function getToken() {
   try {
     return localStorage.getItem(TOKEN_KEY);
@@ -30,13 +36,24 @@ export function clearToken() {
 
 export async function apiFetch(path: string, options: RequestInit = {}) {
   const token = getToken();
+  const headers = new Headers(options.headers);
 
-  return fetch(`${API_BASE}/api${path}`, {
+  if (!headers.has("Content-Type") && !(options.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const res = await fetch(`${API_BASE}/api${path}`, {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(options.headers || {}),
-    },
+    headers,
   });
+
+  if (res.status === 401) {
+    unauthorizedHandler?.();
+  }
+
+  return res;
 }


### PR DESCRIPTION
## Summary

This PR completes v2.3 Sprint 2 and improves the authentication experience across UX, session restore, and app bootstrapping.

## What changed

### Auth UX
- added login/register loading states
- added user-friendly auth error handling
- added client-side validation feedback
- disabled inputs/buttons during submit to prevent duplicate actions

### Session Persistence
- restored auth via `/auth/me` on app load
- handled missing, invalid, and expired tokens safely
- cleared invalid sessions gracefully without crashing

### App Gating
- gated AppShell during auth bootstrap
- added a loading screen while auth resolution is in progress
- prevented unauthenticated UI flicker on refresh

### Token Handling
- hardened token storage access
- added centralized unauthorized response handling
- improved header handling in shared API client

## Acceptance Criteria

- [x] Smooth login/register experience
- [x] Reliable auth restore on reload
- [x] Clear loading and error states
- [x] No UI flicker on refresh
- [x] Invalid sessions handled safely

## Validation

- `npm run build` ✅
- `npm run test` ✅
- manual login/register flow verified ✅
- auth restore after refresh verified ✅
- Invalid token handling verified on app bootstrap (`/auth/me`) and on subsequent authenticated requests.
- Immediate logout after manual token mutation in DevTools (same-tab) is not guaranteed, as the app relies on restore or request-based validation.
- This behavior is expected and aligns with typical client-side auth handling.