### PR TITLE
Readr v2.4 Sprint 0 — Contracts & Derived-State Design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v2.4-sprint-0] — Contracts & Derived-State Design (2026-03-26)
+
+### Added
+
+- Added Sprint 0 docs for v2.4 contracts, architecture, and dependency planning
+- Added shared client type definitions for bulk edit, saved views, stats, and engagement features
+- Added backend type/schema scaffolding for bulk book mutation contracts
+- Added backend type/schema scaffolding for saved library view contracts
+- Added backend type/schema scaffolding for dashboard/statistics read models
+- Added backend type/schema scaffolding for goals, streaks, and badge read models
+
+### Changed
+
+- Updated v2.4 roadmap framing to reflect the broader engagement and insights expansion phase
+- Formalized server-owned derived-state boundaries for engagement and analytics features
+
+### Removed
+
+- None
+
+### Fixed
+
+- Reduced future contract drift by defining initial request/response shapes before implementation
+- Prevented early feature coupling by keeping Sprint 0 limited to docs, schemas, and type-safe contracts
+
+### Notes
+
+- Sprint 0 is a planning and contract checkpoint, not a user-facing feature release
+- Runtime implementation for bulk edit and related v2.4 surfaces begins in Sprint 1
+
+---
+
 ## [v2.3.0] — Identity & Data Ownership (2026-03-25)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### _Turn pages into progress._
 
-A versioned full-stack reading tracker built to demonstrate modern frontend architecture, behavioral parity testing, and CI-gated development.
+A versioned full-stack reading tracker built to demonstrate modern frontend architecture, API-backed system evolution, behavioral parity testing, and CI-gated development.
 
 <p align="center">
 
@@ -11,7 +11,7 @@ A versioned full-stack reading tracker built to demonstrate modern frontend arch
 </a>
 
 <a href="https://github.com/conorgregson/readr-v2/releases/tag/v2.3.0">
-  <img src="https://img.shields.io/badge/Version-v2.3.0-4CAF50?style=for-the-badge" />
+  <img src="https://img.shields.io/badge/Latest%20Release-v2.3.0-4CAF50?style=for-the-badge" />
 </a>
 
 <img src="https://img.shields.io/badge/Frontend-React%20%2B%20TypeScript-008080?style=for-the-badge&logo=react" />
@@ -27,7 +27,7 @@ A versioned full-stack reading tracker built to demonstrate modern frontend arch
 
 <img src="https://img.shields.io/badge/Tests-Full--Stack%20Validated-6A1B9A?style=for-the-badge" />
 
-<img src="https://img.shields.io/badge/Status-v2.3%20Released-4CAF50?style=for-the-badge" />
+<img src="https://img.shields.io/badge/Status-v2.4%20In%20Progress-F9A825?style=for-the-badge" />
 <img src="https://img.shields.io/badge/Commits-Signed%20(Verified)-00C853?style=for-the-badge&logo=github" />
 
 </p>
@@ -49,8 +49,10 @@ The demo is now connected to the **Express + PostgreSQL backend**, with all read
 - **Authentication + user-scoped data now live in v2.3**
 - **Backup export/import now live with ownership enforcement**
 - **Basic auth endpoint rate limiting now protects repeated register/login attempts**
+- **v2.4 is currently in progress**, focused on engagement systems, analytics surfaces, and advanced library workflows
 
-> v2.3 delivers secure multi-user data boundaries, ownership-safe bulk import/export, and authenticated access control across the system.
+> Current stable release: **v2.3.0**
+> Current development milestone: **v2.4 — Engagement & Insights Expansion**
 
 ---
 
@@ -72,7 +74,26 @@ Each version isolates a specific risk area (parity, persistence, ownership) befo
 The original v1.x app remains available here:
 **▶** https://github.com/conorgregson/reading-log-app
 
-> Latest release: **v2.3.0 — Authentication & data ownership**
+> Latest official release: **v2.3.0 — Authentication & data ownership**
+> Current development milestone: **v2.4.0 — Engagement & insights expansion**
+
+---
+
+## Current Development Focus (v2.4)
+
+Readr v2.4 is currently in progress.
+
+This phase expands the stable authenticated, API-backed architecture with a new layer of advanced UX and derived read models, including:
+
+- bulk edit workflows for multi-book mutation
+- saved library views with persistent filters/sorts
+- dashboard statistics and chart-ready summaries
+- reading goals, streaks, and badge progression
+- accessibility, performance, and release hardening for larger libraries
+
+v2.4 is a **feature-layering release**, not an architectural migration.
+
+That means the primary goal is to extend the system safely on top of the stable boundaries established in v2.0–v2.3 rather than rewrite persistence, routing, or ownership architecture again.
 
 ---
 
@@ -325,7 +346,7 @@ During active development, sprint tags are used to mark internal milestones:
 - `v2.1-sprint-0`
 - `v2.1-sprint-1`
 - …
-- `v2.1-sprint-9`
+- sprint tags continue throughout active milestone development
 
 Sprint tags serve as:
 
@@ -343,7 +364,7 @@ Only SemVer releases represent official “ship-ready” states.
 - **v2.1.0** — React frontend rebuild with full v1.9 behavioral parity ✅
 - **v2.2.0** — API integration & persistence migration (local-first → API) ✅
 - **v2.3.0** — Authentication, accounts, and multi-user data boundaries ✅
-- **v2.4.0** — Server-driven badges, statistics, and engagement systems
+- **v2.4.0** — Engagement & insights expansion _(in progress)_ 🚧
 - **v3.0.0** — Production infrastructure & hosted deployment architecture
 
 For detailed version history and architectural milestones, see [`roadmap.md`](./roadmap.md).
@@ -585,7 +606,7 @@ readr-v2/
 │   ├── prisma.config.ts
 │   └── tsconfig.json
 │
-├── docs/                             # Architecture notes, sprint docs, screenshots
+├── docs/                             # Architecture notes, sprint docs, dependency maps, screenshots
 ├── CHANGELOG.md
 ├── roadmap.md
 ├── LICENSE.md
@@ -782,6 +803,19 @@ Backend endpoints are validated via automated API tests.
 v2.1 expands regression protection with parity tests and CI gating.
 
 Engineering choices are documented to emphasize maintainability and long-term scalability.
+
+### 6. Contract-First Feature Expansion (v2.4)
+
+v2.4 begins with a contract-first sprint that defines request/response shapes, derived-state ownership rules, and feature dependencies before implementation expands into UI and mutation behavior.
+
+This approach is used to reduce the risk of:
+
+- inconsistent DTOs
+- duplicated business logic
+- premature UI coupling
+- boundary erosion across frontend and backend layers
+
+By locking these assumptions early, later sprint work can build on stable contracts instead of inventing them during implementation.
 
 ---
 

--- a/client/src/shared/types/v2.4.ts
+++ b/client/src/shared/types/v2.4.ts
@@ -1,0 +1,135 @@
+export type BookStatus = "planned" | "reading" | "finished";
+
+export type SortDirection = "asc" | "desc";
+
+export type LibrarySortKey =
+  | "title"
+  | "author"
+  | "createdAt"
+  | "updatedAt"
+  | "finishedAt";
+
+export type BulkMutationOperation = "update" | "delete";
+
+export type BulkUpdateBooksRequest = {
+  ids: string[];
+  patch: {
+    status?: BookStatus;
+  };
+};
+
+export type BulkDeleteBooksRequest = {
+  ids: string[];
+};
+
+export type BulkMutationResult = {
+  ok: true;
+  operationId: string;
+  operation: BulkMutationOperation;
+  affectedCount: number;
+  affectedIds: string[];
+};
+
+export type SavedLibraryViewFilters = {
+  status?: BookStatus[];
+  favorite?: boolean;
+  search?: string;
+};
+
+export type SavedLibraryViewSort = {
+  key: LibrarySortKey;
+  direction: SortDirection;
+};
+
+export type SavedLibraryView = {
+  id: string;
+  name: string;
+  filters: SavedLibraryViewFilters;
+  sort: SavedLibraryViewSort;
+  isPinned: boolean;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateSavedViewRequest = {
+  name: string;
+  filters: SavedLibraryViewFilters;
+  sort: SavedLibraryViewSort;
+  isPinned?: boolean;
+  isDefault?: boolean;
+};
+
+export type UpdateSavedViewRequest = {
+  name?: string;
+  filters?: SavedLibraryViewFilters;
+  sort?: SavedLibraryViewSort;
+  isPinned?: boolean;
+  isDefault?: boolean;
+};
+
+export type SavedViewsResponse = {
+  items: SavedLibraryView[];
+};
+
+export type DashboardSummaryResponse = {
+  totals: {
+    books: number;
+    finishedBooks: number;
+    pagesRead: number;
+    sessionsLogged: number;
+    avgSessionMinutes: number;
+  };
+  currentPeriod: {
+    booksFinishedThisMonth: number;
+    pagesReadThisMonth: number;
+  };
+};
+
+export type ReadingTrendMetric = "pages" | "sessions" | "booksFinished";
+
+export type TimeSeriesPoint = {
+  date: string; // YYYY-MM-DD
+  value: number;
+};
+
+export type ReadingTrendResponse = {
+  metric: ReadingTrendMetric;
+  points: TimeSeriesPoint[];
+};
+
+export type GoalProgress = {
+  target: number;
+  progress: number;
+  complete: boolean;
+};
+
+export type ReadingGoalsResponse = {
+  yearlyBooksGoal?: GoalProgress;
+  yearlyPagesGoal?: GoalProgress;
+  monthlyBooksGoal?: GoalProgress;
+};
+
+export type ReadingStreakResponse = {
+  currentStreakDays: number;
+  longestStreakDays: number;
+  graceWindowEnabled: boolean;
+};
+
+export type BadgeTier = "bronze" | "silver" | "gold";
+
+export type BadgeProgress = {
+  key: string;
+  title: string;
+  description: string;
+  tier?: BadgeTier;
+  unlocked: boolean;
+  progress: number;
+  target: number;
+};
+
+export type EngagementSnapshotResponse = {
+  goals: ReadingGoalsResponse;
+  streaks: ReadingStreakResponse;
+  badges: BadgeProgress[];
+};

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -24,5 +24,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "../server/src/modules/books/books.bulk.schema.ts", "../server/src/modules/books/books.bulk.types.ts"]
 }

--- a/docs/sprints/v2.4/architecture-v2.4.md
+++ b/docs/sprints/v2.4/architecture-v2.4.md
@@ -1,0 +1,197 @@
+# Readr v2.4 — Architecture Note
+
+## Overview
+
+Readr v2.4 is a feature-expansion release built on the stable authenticated, API-backed architecture established in earlier v2.x versions.
+
+This release does not introduce:
+
+- a persistence migration
+- a major routing rewrite
+- a store architecture rewrite
+- a break in existing CRUD boundaries
+
+Instead, v2.4 layers new workflows and derived read models onto the current system.
+
+Primary feature groups:
+
+- bulk book actions
+- saved library views
+- dashboard statistics
+- goals, streaks, and badges
+
+---
+
+## Architectural Priorities
+
+### 1. Preserve existing layering
+
+Feature work must continue to respect the established boundary:
+
+**UI → store/state → service/API client → server API → persistence**
+
+No feature should bypass those boundaries for convenience.
+
+### 2. Keep derived correctness on the server
+
+Server-derived state is required where correctness, consistency, and trust matter.
+
+This includes:
+
+- badge unlock logic
+- streak calculations
+- summary statistics
+- dashboard aggregates
+
+The UI is responsible for presentation, not authoritative rule evaluation.
+
+### 3. Treat analytics and engagement as read models first
+
+Dashboard, goals, streaks, and badges should enter the system as read-only surfaces before any expansion into richer editing or configuration flows.
+
+This keeps v2.4 focused and avoids overcoupling derived-state features too early.
+
+### 4. Keep bulk actions safe and atomic
+
+Bulk book actions introduce grouped mutation complexity.
+
+That means:
+
+- validation must happen before execution
+- ownership must be enforced before mutation
+- transactions must prevent partial commits
+- grouped Undo must be planned into the response model
+
+### 5. Maintain user ownership boundaries
+
+All v2.4 features must remain scoped to the authenticated user.
+
+This applies to:
+
+- book selection in bulk actions
+- saved views
+- stats
+- engagement progress
+- any future related persistence
+
+---
+
+## Feature Boundaries
+
+# Bulk Edit
+
+Bulk edit is a mutation feature.
+
+Responsibilities:
+
+- server validates all targeted ids
+- server enforces ownership
+- mutation executes atomically
+- response provides grouped operation metadata
+
+Non-goals for Sprint 0:
+
+- broad arbitrary field mutation
+- inline UI implementation
+- undo restoration logic implementation
+
+---
+
+# Saved Views
+
+Saved views are lightweight user-owned preference records.
+
+Responsibilities:
+
+- persist reusable filter + sort state
+- restore library configuration reliably
+- remain scoped per authenticated user
+- fail safely when views are invalid or missing
+
+Saved views are not:
+
+- shared artifacts
+- collaborative objects
+- recommendation systems
+
+---
+
+# Dashboard / Statistics
+
+Dashboard and analytics are read-only aggregate surfaces.
+
+Responsibilities:
+
+- expose stable summary cards
+- support chart-ready payloads
+- remain safe for empty or sparse data
+- avoid any mutation semantics
+
+These surfaces should be computed on the server to preserve consistency across clients and sessions.
+
+---
+
+# Goals / Streaks / Badges
+
+These are engagement read models built from user activity and aggregate state.
+
+Responsibilities:
+
+- derive progress consistently
+- avoid duplicated rule logic in the UI
+- remain renderable in empty states
+- support accessible presentation
+
+The UI may:
+
+- organize
+- sort
+- visually group
+- decorate
+
+The UI should not:
+
+- authoritatively calculate streaks
+- evaluate badge unlock rules
+- recompute goal completion as the source of truth
+
+---
+
+## Why Sprint 0 Is Contract-First
+
+v2.4 touches multiple feature families that depend on shared assumptions.
+
+Without a contract-first phase, the project risks:
+
+- inconsistent DTO shapes
+- duplicated business logic
+- premature UI coupling
+- accidental boundary erosion
+- later refactors to reconcile mismatched assumptions
+
+Sprint 0 exists to reduce that risk before implementation begins.
+
+---
+
+## Non-Goals of v2.4
+
+v2.4 does not include:
+
+- public profiles
+- social reading features
+- shared libraries
+- external integrations
+- AI-generated insights
+- architecture replacement of existing CRUD systems
+
+---
+
+## Success Criteria
+
+v2.4 architecture is successful if:
+
+- new features fit the existing layering model
+- server-owned derived state stays server-owned
+- bulk actions do not compromise integrity
+- analytics remain stable and read-only
+- the UI stays presentation-focused rather than rule-authoritative

--- a/docs/sprints/v2.4/contracts-v2.4.md
+++ b/docs/sprints/v2.4/contracts-v2.4.md
@@ -1,0 +1,417 @@
+# Readr 2.4 — Contracts
+
+## Purpose
+
+This document defines the initial server/client contracts for Readr 2.4.
+
+v2.4 is a feature-layering release built on top of the stable API-backed, authenticated architecture introduced in earlier v2.x versions. This phase does not introduce a persistence migration or architectural rewrite. Its purpose is to establish safe, explicit contracts for:
+
+- bulk edit workflows
+- saved library views
+- dashboard/statistics read models
+- goals, streaks, and badge read models
+
+These contracts are defined before UI implementation so that feature work can proceed without ad hoc modeling or duplicated business logic.
+
+---
+
+## Contract Principles
+
+### 1. No breaking change to core CRUD routes
+
+Existing books and sessions CRUD routes should remain stable unless a change is absolutely necessary.
+
+### 2. Server-owned derived state
+
+Where correctness matters, derived engagement data must be computed on the server rather than reconstructed in the UI.
+
+This applies especially to:
+
+- streaks
+- badge progression
+- dashboard summaries
+- aggregate statistics
+
+### 3. Read-only analytics and engagement surfaces
+
+Dashboard, stats, goals, streaks, and badges should initially be exposed through read-only API responses.
+
+### 4. User ownership enforced at the API boundary
+
+All v2.4 data must remain scoped to the authenticated user. No client-provided ownership field is trusted.
+
+### 5. Bulk mutations must be atomic
+
+Grouped book mutations must succeed or fail as one unit. Partial mutation states must not be exposed.
+
+---
+
+# 1. Bulk Edit Contracts
+
+## Purpose
+
+Bulk edit introduces grouped mutation flows for multiple books at once.
+
+Initial supported operations:
+
+- batch status update
+- batch delete
+
+Future bulk field updates may be added later if they remain safe and consistent.
+
+---
+
+## Request: Batch Update Books
+
+```ts
+type BulkUpdateBooksRequest = {
+  ids: string[];
+  patch: {
+    status?: "planned" | "reading" | "finished";
+  };
+};
+```
+
+---
+
+## Rules
+
+- `id` must be a non-empty array
+- all ids must be valid book ids
+- duplicate ids should be normalized or rejected consistently
+- `patch` must include at least one allowed field
+- all targeted books must belong to the authenticated user
+- operation must be atomic
+
+---
+
+## Request: Batch Delete Books
+
+```ts
+type BulkDeleteBooksRequest = {
+  ids: string[];
+};
+```
+
+## Rules
+
+- `id` must be a non-empty array
+- all ids must be valid book ids
+- duplicate ids should be normalized or rejected consistently
+- all targeted books must belong to the authenticated user
+- operation must be atomic
+
+---
+
+## Response: Bulk Mutation Result
+
+```ts
+type BulkMutationResult = {
+  ok: true;
+  operationId: string;
+  operation: "update" | "delete";
+  affectedCount: number;
+  affectedIds: string[];
+};
+```
+
+---
+
+## Notes
+
+- `operationId` exists to support grouped Undo and operation tracking
+- `affectedIds` should reflect the final resolved set after validation/normalization
+- response shape should remain stable across all bulk book mutation flows
+
+---
+
+## Error Expectations
+
+Examples of invalid requests:
+
+- empty `ids`
+- invalid patch shape
+- unauthorized ownership access
+- malformed ids
+
+Failure behavior:
+
+- grouped operation fails as a unit
+- no partial success response shape
+- no partial commit at persistence layer
+
+---
+
+# 2. Saved Views Contracts
+
+## Purpose
+
+Saved views allow users to persist reusable library configurations across sessions.
+
+A saved view combines:
+
+- filter state
+- sort state
+- naming metadata
+- optional pinned/default behavior
+
+---
+
+## Saved View Shape
+
+```ts
+type SavedLibraryView = {
+  id: string;
+  name: string;
+  filters: {
+    status?: Array<"planned" | "reading" | "finished">;
+    favorite?: boolean;
+    search?: string;
+  };
+  sort: {
+    key: "title" | "author" | "createdAt" | "updatedAt" | "finishedAt";
+    direction: "asc" | "desc";
+  };
+  isPinned: boolean;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+---
+
+## Request: Create Saved View
+
+```ts
+type CreateSavedViewRequest = {
+  name: string;
+  filters: {
+    status?: Array<"planned" | "reading" | "finished">;
+    favorite?: boolean;
+    search?: string;
+  };
+  sort: {
+    key: "title" | "author" | "createdAt" | "updatedAt" | "finishedAt";
+    direction: "asc" | "desc";
+  };
+  isPinned?: boolean;
+  isDefault?: boolean;
+};
+```
+
+---
+
+## Request: Update Saved View
+
+```ts
+type UpdateSavedViewRequest = {
+  name?: string;
+  filters?: {
+    status?: Array<"planned" | "reading" | "finished">;
+    favorite?: boolean;
+    search?: string;
+  };
+  sort?: {
+    key: "title" | "author" | "createdAt" | "updatedAt" | "finishedAt";
+    direction: "asc" | "desc";
+  };
+  isPinned?: boolean;
+  isDefault?: boolean;
+};
+```
+
+---
+
+## Response: Saved Views List
+
+```ts
+type SavedViewsResponse = {
+  items: SavedLibraryView[];
+};
+```
+
+---
+
+## Rules
+
+- saved views are always scoped to the authenticated user
+- only one view may be `isDefault: true` at a time
+- invalid sort keys are rejected at schema boundary
+- deleted or missing default views should degrade safely in the UI
+
+---
+
+# 3. Dashboard / Statistics Contracts
+
+## Purpose
+
+v2.4 introduces read-only statistics and dashboard summaries powered by server-derived aggregates.
+
+These responses are intended for:
+
+- summary cards
+- charts
+- insight surfaces
+
+They are not mutation endpoints.
+
+---
+
+## Response: Dashboard Summary
+
+```ts
+type DashboardSummaryResponse = {
+  totals: {
+    books: number;
+    finishedBooks: number;
+    pagesRead: number;
+    sessionsLogged: number;
+    avgSessionMinutes: number;
+  };
+  currentPeriod: {
+    booksFinishedThisMonth: number;
+    pagesReadThisMonth: number;
+  };
+};
+```
+
+---
+
+## Response: Reading Trend
+
+```ts
+type TimeSeriesPoint = {
+  date: string;
+  value: number;
+};
+
+type ReadingTrendResponse = {
+  metric: "pages" | "sessions" | "booksFinished";
+  points: TimeSeriesPoint[];
+};
+```
+
+---
+
+## Rules
+
+- all analytics responses are read-only
+- values are computed server-side
+- empty libraries should return valid empty-safe responses
+- sparse historical data should not break response shape
+
+---
+
+# 4. Goals / Streaks / Badges Contracts
+
+## Purpose
+
+v2.4 adds motivation systems on top of server-derived stats.
+
+These features must not rely on duplicate UI-side business logic for correctness.
+
+---
+
+# Response: Reading Goals
+
+```ts
+type ReadingGoalsResponse = {
+  yearlyBooksGoal?: {
+    target: number;
+    progress: number;
+    complete: boolean;
+  };
+  yearlyPagesGoal?: {
+    target: number;
+    progress: number;
+    complete: boolean;
+  };
+  monthlyBooksGoal?: {
+    target: number;
+    progress: number;
+    complete: boolean;
+  };
+};
+```
+
+---
+
+## Response: Reading Streaks
+
+```ts
+type ReadingStreakResponse = {
+  currentStreakDays: number;
+  longestStreakDays: number;
+  graceWindowEnabled: boolean;
+};
+```
+
+---
+
+## Response: Badge Progress
+
+```ts
+type BadgeProgress = {
+  key: string;
+  title: string;
+  description: string;
+  tier?: "bronze" | "silver" | "gold";
+  unlocked: boolean;
+  progress: number;
+  target: number;
+};
+```
+
+---
+
+## Response: Engagement Snapshot
+
+```ts
+type EngagementSnapshotResponse = {
+  goals: ReadingGoalsResponse;
+  streaks: ReadingStreakResponse;
+  badges: BadgeProgress[];
+};
+```
+
+---
+
+## Rules
+
+- all engagement responses are read-only in the initial implementation phase
+- streaks and badge progression are computed server-side
+- UI may format or group results but should not recreate business rules
+- empty-state responses must be valid and renderable
+
+---
+
+# 5. Open Decisions
+
+These items are intentionally deferred for implementation discussion:
+
+- whether duplicate ids in bulk mutation are rejected or normalized
+- whether bulk edit expands beyond status changes in v2.4
+- whether monthly page goals are included in initial scope
+- whether streak grace windows are enabled in first release
+- exact badge catalog and milestone thresholds
+- whether saved views persist free-text search or only structural filters
+
+---
+
+# 6. Implementation Notes
+
+Sprint 0 only locks contracts and boundaries.
+
+This phase should prioritize:
+
+- type definitions
+- validation schemas
+- architecture notes
+- endpoint planning
+
+This phase should avoid:
+
+- premature UI wiring
+- duplicated frontend-only derivation logic
+- expanding persistence scope without clear need

--- a/docs/sprints/v2.4/dependency-map-v2.4.md
+++ b/docs/sprints/v2.4/dependency-map-v2.4.md
@@ -1,0 +1,177 @@
+# Readr v2.4 — Dependency Map
+
+## Purpose
+
+This document captures the implementation order and feature dependencies for v2.4.
+
+v2.4 is intentionally structured so that high-risk assumptions are locked early and later UI work builds on stable contracts.
+
+---
+
+## Sprint Order
+
+1. Sprint 0 — Contracts & Derived-State Design
+2. Sprint 1 — Bulk Edit Foundation
+3. Sprint 2 — Saved Views & Library Controls
+4. Sprint 3 — Stats & Dashboard
+5. Sprint 4 — Goals, Streaks & Badges
+6. Sprint 5 — Hardening & Release Lock
+
+---
+
+## Dependency Overview
+
+### Sprint 0
+
+Foundational sprint.
+
+Defines:
+
+- bulk edit contracts
+- saved view model
+- stats/dashboard response shapes
+- goals/streaks/badges domain boundaries
+- server-derived vs UI-derived responsibilities
+
+All later sprints depend on Sprint 0 outputs.
+
+---
+
+### Sprint 1 depends on Sprint 0
+
+Bulk edit requires:
+
+- stable grouped mutation request/response shapes
+- atomicity rules
+- ownership enforcement rules
+- grouped Undo planning
+
+Sprint 1 should not invent contract shapes during UI implementation.
+
+---
+
+### Sprint 2 depends on Sprint 0
+
+Saved views require:
+
+- a stable persistence model
+- valid filter/sort schema
+- rules for pinned/default behavior
+- fallback behavior for missing/invalid views
+
+Sprint 2 should not define persistence behavior ad hoc.
+
+---
+
+### Sprint 3 depends on Sprint 0
+
+Stats/dashboard requires:
+
+- stable read-only summary contracts
+- chart-ready aggregate response shapes
+- server-owned derivation rules
+- empty-state-safe response rules
+
+Sprint 3 should not derive authoritative dashboard logic in the client.
+
+---
+
+### Sprint 4 depends on Sprint 0 and Sprint 3
+
+Goals, streaks, and badges require:
+
+- engagement response contracts from Sprint 0
+- supporting aggregate/stat assumptions from Sprint 3
+- clear boundary between presentation and evaluation logic
+
+Sprint 4 should build on stable metrics rather than invent parallel derived-state paths.
+
+---
+
+### Sprint 5 depends on all prior sprints
+
+Hardening and release lock validates:
+
+- bulk edit safety
+- saved view correctness
+- dashboard stability
+- engagement correctness
+- accessibility and performance across the full release
+
+---
+
+## Recommended Build Order Within Sprint 0
+
+1. contracts-v2.4.md
+2. architecture-v2.4.md
+3. dependency-map-v2.4.md
+4. shared client types
+5. backend schema/type definitions
+6. placeholder module structure if needed
+
+---
+
+## Cross-Feature Risk Notes
+
+### Risk: duplicated business logic
+
+Most likely in:
+
+- streak calculations
+- badge evaluation
+- dashboard summaries
+
+Mitigation:
+
+- define server-owned rules early
+- keep UI presentation-only where correctness matters
+
+### Risk: boundary erosion
+
+Most likely in:
+
+- direct UI-side contract invention
+- feature-specific shortcuts around existing store/service/API flow
+
+Mitigation:
+
+- preserve current layering
+- define DTOs before implementation
+
+### Risk: partial mutation behavior
+
+Most likely in:
+
+- grouped updates
+- grouped deletes
+- future Undo support
+
+Mitigation:
+
+- require atomicity
+- define grouped operation result shape early
+
+### Risk: unstable feature scope
+
+Most likely in:
+
+- saved views expanding too broadly
+- engagement systems growing beyond read-only scope
+- analytics surfacing mutation/configuration needs too early
+
+Mitigation:
+
+- keep v2.4 feature layering disciplined
+- separate initial read models from future expansion ideas
+
+---
+
+## Exit Condition for Sprint 0
+
+Sprint 0 is complete when:
+
+- v2.4 contracts are documented
+- architectural boundaries are explicitly stated
+- dependency order is clear
+- shared type/schema groundwork exists
+- Sprint 1 can begin without inventing core shapes on the fly

--- a/docs/sprints/v2.4/v2.4-feature-expansion-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-feature-expansion-blueprint.md
@@ -1,4 +1,4 @@
-# Readr v2.3 — Feature Expansion Blueprint
+# Readr v2.4 — Feature Expansion Blueprint
 
 Post-API Growth Phase
 
@@ -6,7 +6,7 @@ Post-API Growth Phase
 
 # Purpose
 
-v2.3 reintroduces and expands advanced UX features that existed in v1.9
+v2.4 reintroduces and expands advanced UX features that existed in v1.9
 and were intentionally deferred during the v2.1 frontend rebuild
 and v2.2 API migration.
 
@@ -26,9 +26,10 @@ All expansion occurs on top of a stable API-backed architecture.
 - v2.0 — Backend & CI foundation
 - v2.1 — React frontend rebuild (parity lock)
 - v2.2 — API integration & persistence migration
-- v2.3 — Feature expansion (this phase)
+- v2.3 — Identity & data ownership
+- v2.4 — Feature expansion (this phase)
 
-No architectural migration occurs in v2.3.
+No architectural migration occurs in v2.4.
 Only controlled feature layering.
 
 ---
@@ -76,7 +77,7 @@ Enable multi-book mutation workflows without breaking undo or integrity rules.
 
 ### Architecture
 
-- Computed on server in v2.3+
+- Computed on server in v2.4+
 - Not derived purely in UI
 - Exposed via read-only API endpoint
 
@@ -119,7 +120,7 @@ Server-backed persistence.
 | Charts        | Tier 2                 |
 | Saved Filters | Tier 1                 |
 
-No Tier 0 freeze required for v2.3.
+No Tier 0 freeze required for v2.4.
 
 ---
 
@@ -132,7 +133,7 @@ No Tier 0 freeze required for v2.3.
 
 ---
 
-# Exit Criteria for v2.3
+# Exit Criteria for v2.4
 
 - Bulk edit supports grouped Undo
 - Badges correctly derive from API

--- a/docs/sprints/v2.4/v2.4-sprint-0-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-sprint-0-blueprint.md
@@ -1,0 +1,54 @@
+# Sprint 0 Blueprint — Contracts & Derived-State Design
+
+Readr v2.4
+
+Objective:
+Define the server/client contracts for engagement features before UI expansion begins.
+
+---
+
+# Sprint 0 Goal
+
+- Bulk edit contracts locked
+- Saved view persistence model defined
+- Stats, goals, streaks, and badges modeled clearly
+- Server-owned derived-state boundaries documented
+
+---
+
+# Scope
+
+## Contracts
+
+- Define bulk edit request/response shapes
+- Define saved view schema
+- Define stats response shapes
+- Define goal, streak, and badge DTOs
+
+---
+
+## Architecture Decisions
+
+- Decide what is computed server-side vs client-side
+- Keep engagement logic out of ad hoc UI derivation
+- Preserve store → service → API boundaries
+- Ensure no breaking API changes to existing CRUD routes
+
+---
+
+## Docs
+
+- Create v2.3 architecture note
+- Create v2.4 dependency map
+- Define derived-state rules
+- Document performance assumptions for large libraries
+
+---
+
+# Acceptance Criteria
+
+- Bulk edit contract documented before implementation
+- Saved view persistence model finalized
+- Badge/streak/goal ownership clearly defined
+- No UI-first modeling of server-owned engagement data
+- v2.4 dependency boundaries documented

--- a/docs/sprints/v2.4/v2.4-sprint-1-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-sprint-1-blueprint.md
@@ -1,0 +1,54 @@
+# Sprint 1 Blueprint — Bulk Edit Foundation
+
+Readr v2.4
+
+Objective:
+Introduce multi-book mutation safely without regressing undo, integrity, or API boundaries.
+
+---
+
+# Sprint 1 Goal
+
+- Users can select multiple books
+- Batch mutations work safely
+- Grouped Undo supported
+- No partial mutation states
+
+--
+
+# Scope
+
+## Frontend
+
+- Multi-select UI for books
+- Selection state management
+- Batch action toolbar
+- Batch status update flow
+- Batch delete flow
+
+---
+
+## Backend
+
+- Atomic batch mutation endpoint(s)
+- Validation for multi-object mutation input
+- Safe grouped rollback behavior for failed operations
+- Integrity enforcement at API layer
+
+---
+
+## Undo
+
+- Extend Undo model for grouped operations
+- Preserve filters, search state, and ordering after rollback
+- Avoid regressions in existing single-item Undo flows
+
+---
+
+# Acceptance Criteria
+
+- Users can batch update multiple books
+- Users can batch delete multiple books
+- Grouped Undo restores affected records correctly
+- No partial success state is exposed to the UI
+- Existing CRUD tests remain green

--- a/docs/sprints/v2.4/v2.4-sprint-2-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-sprint-2-blueprint.md
@@ -1,0 +1,54 @@
+# Sprint 2 Blueprint — Saved Views & Advanced Library Controls
+
+Readr v2.4
+
+Objective:
+Improve usability for larger libraries with persistent, user-scoped library views.
+
+---
+
+# Sprint 2 Goal
+
+- Users can save and reuse library views
+- Filters persist server-side
+- View switching is fast and reliable
+- Large-library browsing becomes more efficient
+
+---
+
+# Scope
+
+## Saved Views
+
+- Save filter presets
+- Save sort state
+- Name saved views
+- Quick-toggle between saved views
+- Pin favorite/default view
+
+---
+
+## Persistence
+
+- Server-backed user-scoped persistence
+- Stable serialization of view definitions
+- Safe restore after login/session recovery
+
+---
+
+## UX
+
+- View switcher UI
+- Favorite/pinned default view affordance
+- Empty-state handling for missing/deleted views
+- No regression in search/filter interactions
+
+---
+
+# Acceptance Criteria
+
+- Users can save and reapply named library views
+- Saved views persist across refresh and login restore
+- Filters + sort restore correctly
+- Search/filter/view interactions remain stable
+- Library UX remains performant with large datasets

--- a/docs/sprints/v2.4/v2.4-sprint-3-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-sprint-3-blueprint.md
@@ -1,0 +1,56 @@
+# Sprint 3 Blueprint — Stats & Dashboard
+
+Readr v2.4
+
+Objective:
+Introduce server-derived reading statistics and insight surfaces without adding mutation complexity.
+
+---
+
+# Sprint 3 Goal
+
+- Stats exposed via read-only API
+- Dashboard summary UI added
+- Charts render meaningful user progress
+- Derived metrics remain consistent and scalable
+
+# Scope
+
+## Statistics
+
+- Total books
+- Books finished
+- Pages read
+- Sessions logged
+- Average session length
+- Books finished this month
+- Pages read this month
+- Longest streak / current streak hooks if needed
+
+---
+
+## Visualizations
+
+- Reading over time
+- Pages per month
+- Session duration trends
+- Format breakdown
+
+---
+
+## Constraints
+
+- Charts are view-only
+- No mutation through analytics surfaces
+- Aggregation logic computed server-side
+- UI consumes stable API summaries only
+
+---
+
+# Acceptance Criteria
+
+- Stats are derived from API-backed data
+- Dashboard cards render correctly
+- Charts consume stable read-only responses
+- No regression in books or sessions flows
+- Performance remains acceptable with larger datasets

--- a/docs/sprints/v2.4/v2.4-sprint-4-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-sprint-4-blueprint.md
@@ -1,0 +1,63 @@
+# Sprint 4 Blueprint — Goals, Streaks & Badges
+
+Readr v2.4
+
+Objective:
+Add motivation systems on top of the stats foundation using server-driven derived progress.
+
+---
+
+# Sprint 4 Goal
+
+- Reading goals implemented
+- Streak system implemented
+- Badge progression implemented
+- Progress surfaces are accessible and consistent
+
+---
+
+# Scope
+
+## Goals
+
+- Yearly books goal
+- Yearly pages goal
+- Optional monthly goal
+- Goal progress summaries
+
+---
+
+## Streaks
+
+- Consecutive day tracking
+- Reset rules
+- Optional grace window
+- Current and longest streak display
+
+---
+
+## Badges
+
+- Total books milestones
+- Pages milestones
+- Reading streak milestones
+- Session consistency milestones
+- Tiered presentation/progress display
+
+---
+
+## API / Architecture
+
+- Badge/streak/goal state computed server-side
+- Exposed through read-only API responses
+- No duplicate derivation logic in UI
+
+---
+
+# Acceptance Criteria
+
+- Goals render from stable derived data
+- Streaks calculate consistently across refreshes
+- Badge progress reflects API truth
+- Progress indicators are accessible
+- Motivation systems do not violate architectural boundaries

--- a/docs/sprints/v2.4/v2.4-sprint-5-blueprint.md
+++ b/docs/sprints/v2.4/v2.4-sprint-5-blueprint.md
@@ -1,0 +1,73 @@
+# Sprint 5 Blueprint — Hardening, Accessibility & Release Lock
+
+Readr v2.4
+
+Objective:
+Stabilize the full engagement and insights layer for release.
+
+---
+
+# Sprint 5 Goal
+
+- No CRUD regressions
+- Accessibility baseline preserved
+- Large-library performance validated
+- Release docs updated
+- v2.4 ready for tag
+
+---
+
+# Scope
+
+## Regression Validation
+
+Re-run:
+
+- Books CRUD
+- Sessions CRUD
+- Auth/session restore
+- Bulk edit flows
+- Saved view flows
+- Dashboard rendering
+- Goal/streak/badge surfaces
+- Undo behavior
+
+---
+
+## Hardening
+
+Verify:
+
+- Accessibility of charts and progress indicators
+- Keyboard flows for batch actions and saved views
+- Empty/error/loading states across new surfaces
+- API contract consistency
+- No boundary violations between UI, store, service, and API
+
+---
+
+## Performance
+
+- Validate behavior with 2,000+ books
+- Confirm dashboard queries remain acceptable
+- Confirm bulk operations remain stable under larger datasets
+
+---
+
+## Release Prep
+
+- Update README
+- Update roadmap
+- Update changelog
+- Prepare release notes
+- Clean temporary scaffolding or feature flags if used
+
+---
+
+# Acceptance Criteria
+
+- No regression in CRUD or ownership-sensitive flows
+- Accessibility baseline preserved across new features
+- Performance acceptable with large libraries
+- Documentation updated for v2.4
+- v2.4 ready for official release

--- a/roadmap.md
+++ b/roadmap.md
@@ -210,19 +210,30 @@ Release: Mar 2026
 
 ---
 
-## 🎖️ Version 2.4 — Badge System Overhaul
+## 🎖️ Version 2.4 — Engagement & Insights Expansion
 
-**Focus:** Move gamification logic server-side and make badges scalable
+**Focus:** Reintroduce advanced UX and motivation systems on top of the stable API-backed, user-owned architecture.
 
 ### Planned Work
 
-- Badge definitions and progress tracking in DB
-- Server-side evaluation engine
-- Tiered badge system
-- Accessible UI with progress indicators
-- Snapshot and stats integration
+- Add bulk edit workflows for multi-book mutation
+- Add grouped Undo support for batch operations
+- Add saved views with server-backed filter persistence
+- Introduce server-derived reading statistics and summaries
+- Add streak tracking and badge progression
+- Add reading goals and progress surfaces
+- Add dashboard insights and chart-based visualizations
+- Preserve CRUD correctness, accessibility, and performance at scale
 
-Planned: TBD
+### Notes
+
+- v2.4 is a controlled feature-layering release, not an architectural migration.
+- Derived engagement data should be computed server-side where correctness matters.
+- Bulk operations must preserve integrity, atomicity, and Undo guarantees.
+- Performance should remain acceptable with large user libraries.
+- Social, public, and multi-user collaborative features remain out of scope for this phase.
+
+Planned: Q2 2026
 
 ---
 

--- a/server/src/modules/books/books.bulk.schema.ts
+++ b/server/src/modules/books/books.bulk.schema.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const bookStatusSchema = z.enum(["planned", "reading", "finished"]);
+
+const nonEmptyIdsSchema = z
+  .array(z.string().min(1, "Book ID is required"))
+  .min(1, "At least one book ID is required");
+
+export const bulkUpdateBooksPatchSchema = z
+  .object({
+    status: bookStatusSchema.optional(),
+  })
+  .refine(
+    (patch) => Object.values(patch).some((value) => value !== undefined),
+    {
+      message: "At least one field must be provided to update books",
+    },
+  );
+
+export const bulkUpdateBooksRequestSchema = z.object({
+  ids: nonEmptyIdsSchema,
+  patch: bulkUpdateBooksPatchSchema,
+});
+
+export const bulkDeleteBooksRequestSchema = z.object({
+  ids: nonEmptyIdsSchema,
+});
+
+export const bulkMutationResultSchema = z.object({
+  ok: z.literal(true),
+  operationId: z.string().min(1, "Operation ID is required"),
+  operation: z.enum(["update", "delete"]),
+  affectedCount: z.number().int().nonnegative(),
+  affectedIds: z.array(z.string().min(1)).min(1),
+});
+
+export type BulkUpdateBooksRequestInput = z.infer<
+  typeof bulkUpdateBooksRequestSchema
+>;
+
+export type BulkDeleteBooksRequestInput = z.infer<
+  typeof bulkDeleteBooksRequestSchema
+>;
+
+export type BulkMutationResultOutput = z.infer<typeof bulkMutationResultSchema>;

--- a/server/src/modules/books/books.bulk.types.ts
+++ b/server/src/modules/books/books.bulk.types.ts
@@ -1,0 +1,22 @@
+export type BookStatus = "planned" | "reading" | "finished";
+
+export type BulkMutationOperation = "update" | "delete";
+
+export type BulkUpdateBooksRequest = {
+  ids: string[];
+  patch: {
+    status?: BookStatus;
+  };
+};
+
+export type BulkDeleteBooksRequest = {
+  ids: string[];
+};
+
+export type BulkMutationResult = {
+  ok: true;
+  operationId: string;
+  operation: BulkMutationOperation;
+  affectedCount: number;
+  affectedIds: string[];
+};

--- a/server/src/modules/engagement/engagement.schema.ts
+++ b/server/src/modules/engagement/engagement.schema.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const goalProgressSchema = z.object({
+  target: z.number().int().positive(),
+  progress: z.number().int().nonnegative(),
+  complete: z.boolean(),
+});
+
+export const readingGoalsResponseSchema = z.object({
+  yearlyBooksGoal: goalProgressSchema.optional(),
+  yearlyPagesGoal: goalProgressSchema.optional(),
+  monthlyBooksGoal: goalProgressSchema.optional(),
+});
+
+export const readingStreakResponseSchema = z.object({
+  currentStreakDays: z.number().int().nonnegative(),
+  longestStreakDays: z.number().int().nonnegative(),
+  graceWindowEnabled: z.boolean(),
+});
+
+export const badgeTierSchema = z.enum(["bronze", "silver", "gold"]);
+
+export const badgeProgressSchema = z.object({
+  key: z.string().trim().min(1, "Badge key is required"),
+  title: z.string().trim().min(1, "Badge title is required"),
+  description: z.string().trim().min(1, "Badge description is required"),
+  tier: badgeTierSchema.optional(),
+  unlocked: z.boolean(),
+  progress: z.number().int().nonnegative(),
+  target: z.number().int().positive(),
+});
+
+export const engagementSnapshotResponseSchema = z.object({
+  goals: readingGoalsResponseSchema,
+  streaks: readingStreakResponseSchema,
+  badges: z.array(badgeProgressSchema),
+});
+
+export type GoalProgressOutput = z.infer<typeof goalProgressSchema>;
+
+export type ReadingGoalsResponseOutput = z.infer<
+  typeof readingGoalsResponseSchema
+>;
+
+export type ReadingStreakResponseOutput = z.infer<
+  typeof readingStreakResponseSchema
+>;
+
+export type BadgeTierInput = z.infer<typeof badgeTierSchema>;
+
+export type BadgeProgressOutput = z.infer<typeof badgeProgressSchema>;
+
+export type EngagementSnapshotResponseOutput = z.infer<
+  typeof engagementSnapshotResponseSchema
+>;

--- a/server/src/modules/engagement/engagement.types.ts
+++ b/server/src/modules/engagement/engagement.types.ts
@@ -1,0 +1,35 @@
+export type GoalProgress = {
+  target: number;
+  progress: number;
+  complete: boolean;
+};
+
+export type ReadingGoalsResponse = {
+  yearlyBooksGoal?: GoalProgress;
+  yearlyPagesGoal?: GoalProgress;
+  monthlyBooksGoal?: GoalProgress;
+};
+
+export type ReadingStreakResponse = {
+  currentStreakDays: number;
+  longestStreakDays: number;
+  graceWindowEnabled: boolean;
+};
+
+export type BadgeTier = "bronze" | "silver" | "gold";
+
+export type BadgeProgress = {
+  key: string;
+  title: string;
+  description: string;
+  tier?: BadgeTier;
+  unlocked: boolean;
+  progress: number;
+  target: number;
+};
+
+export type EngagementSnapshotResponse = {
+  goals: ReadingGoalsResponse;
+  streaks: ReadingStreakResponse;
+  badges: BadgeProgress[];
+};

--- a/server/src/modules/stats/stats.schema.ts
+++ b/server/src/modules/stats/stats.schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+export const dashboardSummaryResponseSchema = z.object({
+  totals: z.object({
+    books: z.number().int().nonnegative(),
+    finishedBooks: z.number().int().nonnegative(),
+    pagesRead: z.number().int().nonnegative(),
+    sessionsLogged: z.number().int().nonnegative(),
+    avgSessionMinutes: z.number().nonnegative(),
+  }),
+  currentPeriod: z.object({
+    booksFinishedThisMonth: z.number().int().nonnegative(),
+    pagesReadThisMonth: z.number().int().nonnegative(),
+  }),
+});
+
+export const readingTrendMetricSchema = z.enum([
+  "pages",
+  "sessions",
+  "booksFinished",
+]);
+
+export const timeSeriesPointSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD"),
+  value: z.number().nonnegative(),
+});
+
+export const readingTrendResponseSchema = z.object({
+  metric: readingTrendMetricSchema,
+  points: z.array(timeSeriesPointSchema),
+});
+
+export type DashboardSummaryResponseOutput = z.infer<
+  typeof dashboardSummaryResponseSchema
+>;
+
+export type ReadingTrendMetricInput = z.infer<typeof readingTrendMetricSchema>;
+
+export type TimeSeriesPointOutput = z.infer<typeof timeSeriesPointSchema>;
+
+export type ReadingTrendResponseOutput = z.infer<
+  typeof readingTrendResponseSchema
+>;

--- a/server/src/modules/stats/stats.types.ts
+++ b/server/src/modules/stats/stats.types.ts
@@ -1,0 +1,25 @@
+export type DashboardSummaryResponse = {
+  totals: {
+    books: number;
+    finishedBooks: number;
+    pagesRead: number;
+    sessionsLogged: number;
+    avgSessionMinutes: number;
+  };
+  currentPeriod: {
+    booksFinishedThisMonth: number;
+    pagesReadThisMonth: number;
+  };
+};
+
+export type ReadingTrendMetric = "pages" | "sessions" | "booksFinished";
+
+export type TimeSeriesPoint = {
+  date: string;
+  value: number;
+};
+
+export type ReadingTrendResponse = {
+  metric: ReadingTrendMetric;
+  points: TimeSeriesPoint[];
+};

--- a/server/src/modules/views/views.schema.ts
+++ b/server/src/modules/views/views.schema.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+const bookStatusSchema = z.enum(["planned", "reading", "finished"]);
+
+const sortDirectionSchema = z.enum(["asc", "desc"]);
+
+const librarySortKeySchema = z.enum([
+  "title",
+  "author",
+  "createdAt",
+  "updatedAt",
+  "finishedAt",
+]);
+
+export const savedLibraryViewFiltersSchema = z.object({
+  status: z.array(bookStatusSchema).min(1).optional(),
+  favorite: z.boolean().optional(),
+  search: z.string().trim().min(1).optional(),
+});
+
+export const savedLibraryViewSortSchema = z.object({
+  key: librarySortKeySchema,
+  direction: sortDirectionSchema,
+});
+
+export const savedLibraryViewSchema = z.object({
+  id: z.string().min(1, "View ID is required"),
+  name: z.string().trim().min(1, "View name is required"),
+  filters: savedLibraryViewFiltersSchema,
+  sort: savedLibraryViewSortSchema,
+  isPinned: z.boolean(),
+  isDefault: z.boolean(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const createSavedViewRequestSchema = z.object({
+  name: z.string().trim().min(1, "View name is required"),
+  filters: savedLibraryViewFiltersSchema,
+  sort: savedLibraryViewSortSchema,
+  isPinned: z.boolean().optional(),
+  isDefault: z.boolean().optional(),
+});
+
+export const updateSavedViewRequestSchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    filters: savedLibraryViewFiltersSchema.optional(),
+    sort: savedLibraryViewSortSchema.optional(),
+    isPinned: z.boolean().optional(),
+    isDefault: z.boolean().optional(),
+  })
+  .refine(
+    (input) => Object.values(input).some((value) => value !== undefined),
+    {
+      message: "At least one field must be provided to update a saved view",
+    },
+  );
+
+export const savedViewsResponseSchema = z.object({
+  items: z.array(savedLibraryViewSchema),
+});
+
+export type SavedLibraryViewFiltersInput = z.infer<
+  typeof savedLibraryViewFiltersSchema
+>;
+
+export type SavedLibraryViewSortInput = z.infer<
+  typeof savedLibraryViewSortSchema
+>;
+
+export type SavedLibraryViewInput = z.infer<typeof savedLibraryViewSchema>;
+
+export type CreateSavedViewRequestInput = z.infer<
+  typeof createSavedViewRequestSchema
+>;
+
+export type UpdateSavedViewRequestInput = z.infer<
+  typeof updateSavedViewRequestSchema
+>;
+
+export type SavedViewsResponseOutput = z.infer<typeof savedViewsResponseSchema>;

--- a/server/src/modules/views/views.types.ts
+++ b/server/src/modules/views/views.types.ts
@@ -1,0 +1,52 @@
+export type BookStatus = "planned" | "reading" | "finished";
+
+export type SortDirection = "asc" | "desc";
+
+export type LibrarySortKey =
+  | "title"
+  | "author"
+  | "createdAt"
+  | "updatedAt"
+  | "finishedAt";
+
+export type SavedLibraryViewFilters = {
+  status?: BookStatus[];
+  favorite?: boolean;
+  search?: string;
+};
+
+export type SavedLibraryViewSort = {
+  key: LibrarySortKey;
+  direction: SortDirection;
+};
+
+export type SavedLibraryView = {
+  id: string;
+  name: string;
+  filters: SavedLibraryViewFilters;
+  sort: SavedLibraryViewSort;
+  isPinned: boolean;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateSavedViewRequest = {
+  name: string;
+  filters: SavedLibraryViewFilters;
+  sort: SavedLibraryViewSort;
+  isPinned?: boolean;
+  isDefault?: boolean;
+};
+
+export type UpdateSavedViewRequest = {
+  name?: string;
+  filters?: SavedLibraryViewFilters;
+  sort?: SavedLibraryViewSort;
+  isPinned?: boolean;
+  isDefault?: boolean;
+};
+
+export type SavedViewsResponse = {
+  items: SavedLibraryView[];
+};


### PR DESCRIPTION
## Summary

This PR starts Readr v2.4 with a contract-first Sprint 0 focused on architectural clarity and derived-state boundaries.

Rather than jumping directly into UI or mutation behavior, this sprint locks the initial request/response shapes and supporting docs for the major v2.4 feature families:

- bulk edit
- saved views
- dashboard/statistics
- goals, streaks, and badges

This keeps v2.4 aligned with Readr’s versioned development model: define boundaries first, then layer implementation on top of stable contracts.

---

## What changed

### Docs
- Added `docs/sprints/v2.4/contracts-v2.4.md`
- Added `docs/sprints/v2.4/architecture-v2.4.md`
- Added `docs/sprints/v2.4/dependency-map-v2.4.md`

### Client
- Added shared v2.4 type definitions for upcoming feature work

### Server
- Added bulk mutation types/schemas
- Added saved views types/schemas
- Added stats types/schemas
- Added engagement types/schemas

### Roadmap
- Updated v2.4 framing to reflect the broader engagement and insights expansion phase

---

## Why

v2.4 introduces multiple feature families that depend on shared assumptions around:

- atomic bulk mutation
- user-scoped saved views
- read-only analytics surfaces
- server-owned derived engagement state

Locking these contracts early reduces the risk of:
- inconsistent DTOs
- duplicated business logic
- premature UI coupling
- boundary erosion across client and server layers

---

## Scope notes

This sprint does **not** implement full runtime behavior yet.

Sprint 0 is intentionally limited to:
- docs
- type definitions
- validation schemas
- dependency planning

It does **not** yet include:
- bulk mutation routes/services
- saved view persistence behavior
- dashboard endpoints
- badge/streak evaluation logic
- UI wiring

---

## Validation
- Type-level scaffolding added for client and server
- Zod schemas added for initial backend contract enforcement
- Sprint 1 can now begin from stable shapes instead of inventing contracts during implementation